### PR TITLE
renderer 탭 지연 로딩으로 초기 번들 최적화

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rosemary-app",
-	"version": "8.3.2",
+	"version": "8.3.3",
 	"description": "An Electron application with React and TypeScript",
 	"main": "./out/main/index.js",
 	"author": "example.com",

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	lazy,
+	Suspense,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
 import type {
 	DuplicateCheckResult,
 	FavoriteArtistCandidate,
@@ -11,18 +19,13 @@ import type {
 } from "../../shared/file-organizer";
 import type { OrganizationReviewIssue } from "../../shared/organization-metadata";
 import {
-	CrawlerDbPanel,
-	CrawlerPanel,
 	EmptyState,
 	FileTable,
 	GearIcon,
 	Header,
 	LoadingState,
 	NoResults,
-	RandomReviewPanel,
 	RosemaryBrand,
-	Settings,
-	SimilarGroupPanel,
 	Stats,
 } from "./components";
 import { useArchiveMetadataRecovery } from "./hooks/useArchiveMetadataRecovery";
@@ -41,6 +44,36 @@ import { getRelativePath, parseFileStructure } from "./utils/file";
 
 type AppTab = "files" | "crawler" | "crawler-db" | "similar" | "review";
 type FileReviewPhase = "idle" | "checking" | "complete" | "failed";
+
+const CrawlerDbPanel = lazy(async () => {
+	const module = await import("./components/CrawlerDbPanel");
+	return { default: module.CrawlerDbPanel };
+});
+const CrawlerPanel = lazy(async () => {
+	const module = await import("./components/CrawlerPanel");
+	return { default: module.CrawlerPanel };
+});
+const RandomReviewPanel = lazy(async () => {
+	const module = await import("./components/RandomReviewPanel");
+	return { default: module.RandomReviewPanel };
+});
+const Settings = lazy(async () => {
+	const module = await import("./components/Settings");
+	return { default: module.Settings };
+});
+const SimilarGroupPanel = lazy(async () => {
+	const module = await import("./components/SimilarGroupPanel");
+	return { default: module.SimilarGroupPanel };
+});
+
+const DeferredPanelFallback = (): React.JSX.Element => (
+	<output
+		className="flex min-h-0 flex-1 items-center justify-center"
+		aria-label="화면 불러오는 중"
+	>
+		<span className="loading loading-spinner loading-md" />
+	</output>
+);
 
 const isScanArchiveResult = (value: unknown): value is ScanArchiveResult =>
 	typeof value === "object" &&
@@ -700,72 +733,78 @@ function App(): React.JSX.Element {
 					</div>
 				</div>
 
-				{activeTab === "files" ? (
-					<>
-						<Header
-							selectedPath={selectedPath}
-							isScanning={isScanning}
-							thumbnailEnabled={thumbnailEnabled}
-							onSelectPath={getPath}
-							onScanFiles={scanFiles}
-							onThumbnailEnabledChange={setThumbnailEnabled}
-						/>
+				<Suspense fallback={<DeferredPanelFallback />}>
+					{activeTab === "files" ? (
+						<>
+							<Header
+								selectedPath={selectedPath}
+								isScanning={isScanning}
+								thumbnailEnabled={thumbnailEnabled}
+								onSelectPath={getPath}
+								onScanFiles={scanFiles}
+								onThumbnailEnabledChange={setThumbnailEnabled}
+							/>
 
-						{isScanning && <LoadingState progress={scanProgress} />}
+							{isScanning && <LoadingState progress={scanProgress} />}
 
-						{!isScanning && !scanComplete && !selectedPath && (
-							<EmptyState onSelectPath={getPath} />
-						)}
+							{!isScanning && !scanComplete && !selectedPath && (
+								<EmptyState onSelectPath={getPath} />
+							)}
 
-						{scanComplete && fileList.length === 0 && <NoResults />}
+							{scanComplete && fileList.length === 0 && <NoResults />}
 
-						{scanComplete && fileList.length > 0 && (
-							<div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
-								<Stats
-									fileList={fileList}
-									selectedPath={selectedPath}
-									fileReviewPhase={fileReviewPhase}
-									scanIndexSummary={scanIndexSummary}
-									onFileListChange={setFileList}
-									onDuplicateActionsChange={handleDuplicateActionsChange}
-								/>
-								<FileTable
-									fileList={fileList}
-									visibleFileIndexes={visibleFileIndexes}
-									activeFilter={activeFileFilter}
-									selectedRowIndex={selectedRowIndex}
-									selectedPath={selectedPath}
-									thumbnailEnabled={thumbnailEnabled}
-									thumbnailProgress={thumbnailProgress}
-									tableContainerRef={tableContainerRef}
-									reviewPhase={fileReviewPhase}
-									onRowClick={handleRowClick}
-									onFilterChange={setActiveFileFilter}
-									onDuplicateActionChange={handleDuplicateActionChange}
-									onGroupTargetChange={handleGroupTargetChange}
-									onCopyFile={handleCopyFile}
-									onMoveFile={handleMoveFile}
-									onKeepFile={handleKeepFile}
-									onMoveToFavoriteArtist={handleMoveToFavoriteArtist}
-									onRequestSourceMetadata={requestSourceMetadata}
-									isRequestingSourceMetadata={isRequestingSourceMetadata}
-								/>
-							</div>
-						)}
-					</>
-				) : activeTab === "review" ? (
-					<RandomReviewPanel />
-				) : activeTab === "similar" ? (
-					<SimilarGroupPanel />
-				) : activeTab === "crawler" ? (
-					<CrawlerPanel />
-				) : (
-					<CrawlerDbPanel />
-				)}
+							{scanComplete && fileList.length > 0 && (
+								<div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
+									<Stats
+										fileList={fileList}
+										selectedPath={selectedPath}
+										fileReviewPhase={fileReviewPhase}
+										scanIndexSummary={scanIndexSummary}
+										onFileListChange={setFileList}
+										onDuplicateActionsChange={handleDuplicateActionsChange}
+									/>
+									<FileTable
+										fileList={fileList}
+										visibleFileIndexes={visibleFileIndexes}
+										activeFilter={activeFileFilter}
+										selectedRowIndex={selectedRowIndex}
+										selectedPath={selectedPath}
+										thumbnailEnabled={thumbnailEnabled}
+										thumbnailProgress={thumbnailProgress}
+										tableContainerRef={tableContainerRef}
+										reviewPhase={fileReviewPhase}
+										onRowClick={handleRowClick}
+										onFilterChange={setActiveFileFilter}
+										onDuplicateActionChange={handleDuplicateActionChange}
+										onGroupTargetChange={handleGroupTargetChange}
+										onCopyFile={handleCopyFile}
+										onMoveFile={handleMoveFile}
+										onKeepFile={handleKeepFile}
+										onMoveToFavoriteArtist={handleMoveToFavoriteArtist}
+										onRequestSourceMetadata={requestSourceMetadata}
+										isRequestingSourceMetadata={isRequestingSourceMetadata}
+									/>
+								</div>
+							)}
+						</>
+					) : activeTab === "review" ? (
+						<RandomReviewPanel />
+					) : activeTab === "similar" ? (
+						<SimilarGroupPanel />
+					) : activeTab === "crawler" ? (
+						<CrawlerPanel />
+					) : (
+						<CrawlerDbPanel />
+					)}
+				</Suspense>
 			</div>
 
 			{/* 설정 모달 */}
-			<Settings isOpen={isSettingsOpen} onClose={handleCloseSettings} />
+			{isSettingsOpen && (
+				<Suspense fallback={null}>
+					<Settings isOpen onClose={handleCloseSettings} />
+				</Suspense>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## 변경 사항
- 크롤러, 크롤러 DB, 유사 그룹, 랜덤 재검토, 설정 화면을 React lazy loading으로 분리했습니다.
- 지연 로딩 중 접근 가능한 로딩 상태를 표시합니다.
- 앱 버전을 8.3.3으로 올렸습니다.

## 목적 및 영향
초기 화면에서 사용하지 않는 탭 코드를 로드하지 않아 renderer 초기 JavaScript를 591.11 kB에서 395.18 kB로 줄였습니다. 기존 탭 상태와 IPC 동작은 유지됩니다.

## 검증
- `pnpm check`
- `pnpm typecheck`
- `pnpm build`