### PR TITLE
Add persistent tag preferences and crawler exclusions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rosemary-app",
-	"version": "8.3.3",
+	"version": "8.4.0",
 	"description": "An Electron application with React and TypeScript",
 	"main": "./out/main/index.js",
 	"author": "example.com",
@@ -15,7 +15,7 @@
 		"typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
 		"typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
 		"typecheck": "pnpm run typecheck:node && pnpm run typecheck:web",
-		"test:metadata": "node --experimental-strip-types --test tests/gallery-metadata.test.mjs tests/organization-metadata.test.mjs tests/archive-metadata-recovery.test.mjs tests/crawler-database.test.mjs tests/crawler-download-dispatch.test.mjs tests/crawler-metadata-integration.test.mjs tests/crawler-request-policy.test.mjs tests/hitomi-catalog-index.test.mjs",
+		"test:metadata": "node --experimental-strip-types --test tests/gallery-metadata.test.mjs tests/organization-metadata.test.mjs tests/archive-metadata-recovery.test.mjs tests/crawler-database.test.mjs tests/crawler-download-dispatch.test.mjs tests/crawler-metadata-integration.test.mjs tests/crawler-request-policy.test.mjs tests/hitomi-catalog-index.test.mjs tests/tag-preferences.test.mjs",
 		"test:startup": "node --experimental-strip-types --test tests/runtime-paths.test.mjs",
 		"smoke:start": "pnpm run build && node scripts/smoke-electron-start.mjs",
 		"start": "electron-vite preview",

--- a/src/main/crawler-database.ts
+++ b/src/main/crawler-database.ts
@@ -11,6 +11,7 @@ const DOWNLOAD_COUNTER_COLUMNS = [
 	"download_sent",
 	"download_invalid",
 	"download_failed",
+	"download_excluded",
 ] as const;
 
 export const getMetadataBackfillFailedGalleryIds = (
@@ -27,6 +28,23 @@ export const getMetadataBackfillFailedGalleryIds = (
 			)
 			.all(jobId) as unknown as Array<{ gallery_id: string }>
 	).map((row) => row.gallery_id);
+
+export const clearCrawlerDatabaseContent = (db: DatabaseSync): void => {
+	db.exec(`
+		DELETE FROM archive_metadata_recovery_items;
+		DELETE FROM archive_metadata_recovery_jobs;
+		DELETE FROM archive_gallery_recovery_state;
+		DELETE FROM archive_gallery_tags;
+		DELETE FROM archive_gallery_metadata;
+		DELETE FROM crawl_metadata_backfill_items;
+		DELETE FROM crawl_metadata_backfill_jobs;
+		DELETE FROM crawl_item_tags;
+		DELETE FROM crawl_item_metadata;
+		DELETE FROM crawl_items;
+		DELETE FROM crawl_runs;
+		DELETE FROM crawl_state;
+	`);
+};
 
 export const initializeCrawlerDatabase = (db: DatabaseSync): void => {
 	db.exec("PRAGMA journal_mode = WAL;");
@@ -50,6 +68,7 @@ export const initializeCrawlerDatabase = (db: DatabaseSync): void => {
 			download_sent INTEGER NOT NULL DEFAULT 0,
 			download_invalid INTEGER NOT NULL DEFAULT 0,
 			download_failed INTEGER NOT NULL DEFAULT 0,
+			download_excluded INTEGER NOT NULL DEFAULT 0,
 			download_last_error TEXT,
 			resume_cursor_before TEXT,
 			resume_cursor_after TEXT,
@@ -120,10 +139,20 @@ export const initializeCrawlerDatabase = (db: DatabaseSync): void => {
 			last_error TEXT,
 			updated_at TEXT NOT NULL,
 			sent_at TEXT,
+			excluded_tag_key TEXT,
 			PRIMARY KEY (run_id, gallery_id),
 			FOREIGN KEY (run_id) REFERENCES crawl_runs(id) ON DELETE CASCADE,
 			FOREIGN KEY (gallery_id) REFERENCES crawl_items(code)
 				ON UPDATE CASCADE ON DELETE CASCADE
+		);
+
+		CREATE TABLE IF NOT EXISTS user_tag_preferences (
+			tag_key TEXT PRIMARY KEY,
+			namespace TEXT NOT NULL,
+			value TEXT NOT NULL,
+			kind TEXT NOT NULL CHECK (kind IN ('preferred', 'excluded')),
+			created_at TEXT NOT NULL,
+			updated_at TEXT NOT NULL
 		);
 
 		CREATE TABLE IF NOT EXISTS crawl_metadata_backfill_jobs (
@@ -254,6 +283,9 @@ export const initializeCrawlerDatabase = (db: DatabaseSync): void => {
 		CREATE INDEX IF NOT EXISTS idx_crawl_download_dispatch_status
 		ON crawl_download_dispatch_items(run_id, status, gallery_id);
 
+		CREATE INDEX IF NOT EXISTS idx_user_tag_preferences_kind
+		ON user_tag_preferences(kind, namespace, value);
+
 		CREATE INDEX IF NOT EXISTS idx_crawl_metadata_backfill_items_status
 		ON crawl_metadata_backfill_items(job_id, status, gallery_id);
 
@@ -289,6 +321,18 @@ export const initializeCrawlerDatabase = (db: DatabaseSync): void => {
 	}
 	if (!runColumnNames.has("download_last_error")) {
 		db.exec("ALTER TABLE crawl_runs ADD COLUMN download_last_error TEXT");
+	}
+	const dispatchColumnNames = new Set(
+		(
+			db
+				.prepare("PRAGMA table_info(crawl_download_dispatch_items)")
+				.all() as Array<{ name: string }>
+		).map((column) => column.name),
+	);
+	if (!dispatchColumnNames.has("excluded_tag_key")) {
+		db.exec(
+			"ALTER TABLE crawl_download_dispatch_items ADD COLUMN excluded_tag_key TEXT",
+		);
 	}
 	const crawlMetadataColumnNames = new Set(
 		(

--- a/src/main/crawler-download-dispatch.ts
+++ b/src/main/crawler-download-dispatch.ts
@@ -1,7 +1,12 @@
 import type { DatabaseSync } from "node:sqlite";
 import type { HitomiApiSendResult } from "../shared/settings.ts";
 
-export type DownloadDispatchStatus = "pending" | "sent" | "invalid" | "failed";
+export type DownloadDispatchStatus =
+	| "pending"
+	| "sent"
+	| "invalid"
+	| "failed"
+	| "excluded";
 
 export interface DownloadDispatchRow {
 	galleryId: string;
@@ -13,7 +18,13 @@ export interface DownloadDispatchSummary {
 	sent: number;
 	invalid: number;
 	failed: number;
+	excluded: number;
 	lastError: string | null;
+}
+
+export interface ExcludedDownloadDispatchRow {
+	galleryId: string;
+	tagKey: string;
 }
 
 export const selectDownloadDispatchRows = (
@@ -53,7 +64,8 @@ export const applyDownloadDispatchResult = (
 	const updateItem = database.prepare(
 		`UPDATE crawl_download_dispatch_items
 		 SET status = ?, attempt_count = attempt_count + 1,
-		     last_error = ?, updated_at = ?, sent_at = ?
+		     last_error = ?, updated_at = ?, sent_at = ?,
+		     excluded_tag_key = NULL
 		 WHERE run_id = ? AND gallery_id = ?`,
 	);
 
@@ -105,10 +117,37 @@ export const markDownloadDispatchRowsFailed = (
 		.prepare(
 			`UPDATE crawl_download_dispatch_items
 			 SET status = 'failed', attempt_count = attempt_count + 1,
-			     last_error = ?, updated_at = ?, sent_at = NULL
+			     last_error = ?, updated_at = ?, sent_at = NULL,
+			     excluded_tag_key = NULL
 			 WHERE run_id = ? AND status IN (${placeholders})`,
 		)
 		.run(errorMessage, updatedAt, runId, ...statuses);
+};
+
+export const markDownloadDispatchRowsExcluded = (
+	database: DatabaseSync,
+	runId: number,
+	rows: ExcludedDownloadDispatchRow[],
+	updatedAt = new Date().toISOString(),
+): void => {
+	if (rows.length === 0) return;
+	const updateItem = database.prepare(
+		`UPDATE crawl_download_dispatch_items
+		 SET status = 'excluded', last_error = NULL, updated_at = ?,
+		     sent_at = NULL, excluded_tag_key = ?
+		 WHERE run_id = ? AND gallery_id = ?`,
+	);
+
+	database.exec("BEGIN IMMEDIATE TRANSACTION");
+	try {
+		for (const row of rows) {
+			updateItem.run(updatedAt, row.tagKey, runId, row.galleryId);
+		}
+		database.exec("COMMIT");
+	} catch (error) {
+		database.exec("ROLLBACK");
+		throw error;
+	}
 };
 
 export const getDownloadDispatchSummary = (
@@ -118,10 +157,11 @@ export const getDownloadDispatchSummary = (
 	const counts = database
 		.prepare(
 			`SELECT
-				COUNT(*) AS requested,
+				SUM(CASE WHEN status <> 'excluded' THEN 1 ELSE 0 END) AS requested,
 				SUM(CASE WHEN status = 'sent' THEN 1 ELSE 0 END) AS sent,
 				SUM(CASE WHEN status = 'invalid' THEN 1 ELSE 0 END) AS invalid,
-				SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed
+				SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed,
+				SUM(CASE WHEN status = 'excluded' THEN 1 ELSE 0 END) AS excluded
 			 FROM crawl_download_dispatch_items
 			 WHERE run_id = ?`,
 		)
@@ -130,6 +170,7 @@ export const getDownloadDispatchSummary = (
 		sent: number | null;
 		invalid: number | null;
 		failed: number | null;
+		excluded: number | null;
 	};
 	const lastFailure = database
 		.prepare(
@@ -140,10 +181,11 @@ export const getDownloadDispatchSummary = (
 		)
 		.get(runId) as { last_error: string | null } | undefined;
 	return {
-		requested: counts.requested,
+		requested: counts.requested ?? 0,
 		sent: counts.sent ?? 0,
 		invalid: counts.invalid ?? 0,
 		failed: counts.failed ?? 0,
+		excluded: counts.excluded ?? 0,
 		lastError: lastFailure?.last_error ?? null,
 	};
 };

--- a/src/main/crawler.ts
+++ b/src/main/crawler.ts
@@ -38,6 +38,14 @@ import {
 	mapGalleryMetadataBatchResponse,
 } from "../shared/gallery-metadata";
 import {
+	getMatchingTagPreferences,
+	getTagPreferenceKey,
+	type TagPreference,
+	type TagPreferenceIdentity,
+	type TagPreferenceInput,
+} from "../shared/tag-preferences";
+import {
+	clearCrawlerDatabaseContent,
 	getMetadataBackfillFailedGalleryIds,
 	initializeCrawlerDatabase,
 } from "./crawler-database";
@@ -45,6 +53,7 @@ import {
 	applyDownloadDispatchResult,
 	type DownloadDispatchStatus,
 	getDownloadDispatchSummary,
+	markDownloadDispatchRowsExcluded,
 	markDownloadDispatchRowsFailed,
 	selectDownloadDispatchRows,
 } from "./crawler-download-dispatch";
@@ -62,6 +71,11 @@ import { sendCodesToHitomiApi } from "./hitomi-api";
 import { getHitomiCatalogPath } from "./hitomi-catalog";
 import { HitomiCatalogIndex } from "./hitomi-catalog-index";
 import { loadSettings } from "./settings";
+import {
+	deleteTagPreference as deleteStoredTagPreference,
+	listTagPreferences as listStoredTagPreferences,
+	upsertTagPreference as upsertStoredTagPreference,
+} from "./tag-preferences";
 
 const BASE_DELAY_MIN_MS = 1500;
 const BASE_DELAY_MAX_MS = 4000;
@@ -105,6 +119,7 @@ interface CrawlRunRow {
 	download_sent: number;
 	download_invalid: number;
 	download_failed: number;
+	download_excluded: number;
 	download_last_error: string | null;
 	resume_cursor_before: string | null;
 	resume_cursor_after: string | null;
@@ -367,6 +382,7 @@ export class CrawlerService {
 			downloadSent: 0,
 			downloadInvalid: 0,
 			downloadFailed: 0,
+			downloadExcluded: 0,
 			downloadLastError: null,
 			currentCursor: null,
 			startedAt,
@@ -438,6 +454,7 @@ export class CrawlerService {
 			downloadSent: lastRun.download_sent,
 			downloadInvalid: lastRun.download_invalid,
 			downloadFailed: lastRun.download_failed,
+			downloadExcluded: lastRun.download_excluded,
 			downloadLastError: lastRun.download_last_error,
 			currentCursor: null,
 			startedAt: lastRun.started_at,
@@ -570,6 +587,18 @@ export class CrawlerService {
 		}
 
 		return metadataByGalleryId;
+	}
+
+	public listTagPreferences(): TagPreference[] {
+		return listStoredTagPreferences(this.db);
+	}
+
+	public upsertTagPreference(input: TagPreferenceInput): TagPreference {
+		return upsertStoredTagPreference(this.db, input);
+	}
+
+	public deleteTagPreference(input: TagPreferenceIdentity): void {
+		deleteStoredTagPreference(this.db, input);
 	}
 
 	public getDatabaseSummary(): CrawlDatabaseSummary {
@@ -1145,20 +1174,7 @@ export class CrawlerService {
 			.prepare("SELECT COUNT(*) AS count FROM crawl_state")
 			.get() as { count: number };
 
-		this.db.exec(`
-			DELETE FROM archive_metadata_recovery_items;
-			DELETE FROM archive_metadata_recovery_jobs;
-			DELETE FROM archive_gallery_recovery_state;
-			DELETE FROM archive_gallery_tags;
-			DELETE FROM archive_gallery_metadata;
-			DELETE FROM crawl_metadata_backfill_items;
-			DELETE FROM crawl_metadata_backfill_jobs;
-			DELETE FROM crawl_item_tags;
-			DELETE FROM crawl_item_metadata;
-			DELETE FROM crawl_items;
-			DELETE FROM crawl_runs;
-			DELETE FROM crawl_state;
-		`);
+		clearCrawlerDatabaseContent(this.db);
 
 		const now = new Date().toISOString();
 		this.db
@@ -2751,13 +2767,39 @@ export class CrawlerService {
 			this.syncDownloadDispatchCounters(runId);
 			return;
 		}
+		const excludedPreferences = this.listTagPreferences().filter(
+			(preference) => preference.kind === "excluded",
+		);
+		const metadataByGalleryId =
+			excludedPreferences.length > 0
+				? this.getMetadataByGalleryIds(rows.map((row) => row.galleryId))
+				: {};
+		const excludedRows: Array<{ galleryId: string; tagKey: string }> = [];
+		const sendRows = rows.filter((row) => {
+			const metadata = metadataByGalleryId[row.galleryId];
+			if (!metadata) return true;
+			const [matchedPreference] = getMatchingTagPreferences(
+				metadata.tags,
+				excludedPreferences,
+			);
+			if (!matchedPreference) return true;
+			const tagKey = getTagPreferenceKey(matchedPreference);
+			if (!tagKey) return true;
+			excludedRows.push({ galleryId: row.galleryId, tagKey });
+			return false;
+		});
+		markDownloadDispatchRowsExcluded(this.db, runId, excludedRows);
+		if (sendRows.length === 0) {
+			this.syncDownloadDispatchCounters(runId);
+			return;
+		}
 
 		try {
 			const result = await sendCodesToHitomiApi(
-				rows.map((row) => row.galleryId),
+				sendRows.map((row) => row.galleryId),
 				await loadSettings(),
 			);
-			applyDownloadDispatchResult(this.db, runId, rows, result);
+			applyDownloadDispatchResult(this.db, runId, sendRows, result);
 		} catch (error) {
 			this.markDownloadDispatchFailed(
 				runId,
@@ -2786,7 +2828,7 @@ export class CrawlerService {
 				`UPDATE crawl_runs
 				 SET download_requested = ?, download_sent = ?,
 				     download_invalid = ?, download_failed = ?,
-				     download_last_error = ?
+				     download_excluded = ?, download_last_error = ?
 				 WHERE id = ?`,
 			)
 			.run(
@@ -2794,6 +2836,7 @@ export class CrawlerService {
 				summary.sent,
 				summary.invalid,
 				summary.failed,
+				summary.excluded,
 				summary.lastError,
 				runId,
 			);
@@ -2804,6 +2847,7 @@ export class CrawlerService {
 				downloadSent: summary.sent,
 				downloadInvalid: summary.invalid,
 				downloadFailed: summary.failed,
+				downloadExcluded: summary.excluded,
 				downloadLastError: summary.lastError,
 			};
 		}
@@ -2895,6 +2939,7 @@ export class CrawlerService {
 			downloadSent: this.currentStatus?.downloadSent ?? 0,
 			downloadInvalid: this.currentStatus?.downloadInvalid ?? 0,
 			downloadFailed: this.currentStatus?.downloadFailed ?? 0,
+			downloadExcluded: this.currentStatus?.downloadExcluded ?? 0,
 			downloadLastError: this.currentStatus?.downloadLastError ?? null,
 			currentCursor: null,
 			startedAt: this.currentStatus?.startedAt ?? finishedAt,
@@ -3034,6 +3079,7 @@ export class CrawlerService {
 			downloadSent: 0,
 			downloadInvalid: 0,
 			downloadFailed: 0,
+			downloadExcluded: 0,
 			downloadLastError: null,
 			currentCursor: null,
 			startedAt: null,

--- a/src/main/files.ts
+++ b/src/main/files.ts
@@ -47,6 +47,7 @@ import {
 	resolveDuplicateTarget,
 	resolveFavoriteArtistTargets,
 } from "../shared/organization-metadata";
+import { matchesAnyTagPreference } from "../shared/tag-preferences";
 import {
 	flushArchiveContentCache,
 	getArchiveContentSummary,
@@ -1243,12 +1244,33 @@ const selectRandomReviewFiles = (
 	indexedFiles: RandomReviewIndexedFile[],
 	options: RandomReviewOptions,
 	limit: number,
+	resolveMetadata?: GalleryMetadataResolver,
 ): { files: FileEntry[]; matchedCount: number } => {
 	const sample: FileEntry[] = [];
 	let matchedCount = 0;
+	const candidateFiles = indexedFiles.filter((file) =>
+		shouldIncludeRandomReviewFile(file, options),
+	);
+	const preferredTags = options.preferredTags ?? [];
+	const metadataByGalleryId =
+		preferredTags.length > 0 && resolveMetadata
+			? resolveMetadata(
+					candidateFiles
+						.map((file) => parseArchiveFileName(file.name).code)
+						.filter((galleryId): galleryId is string => Boolean(galleryId)),
+				)
+			: {};
 
-	for (const file of indexedFiles) {
-		if (!shouldIncludeRandomReviewFile(file, options)) {
+	for (const file of candidateFiles) {
+		const galleryId = parseArchiveFileName(file.name).code;
+		const sourceMetadata = galleryId
+			? metadataByGalleryId[galleryId]
+			: undefined;
+		if (
+			preferredTags.length > 0 &&
+			(!sourceMetadata ||
+				!matchesAnyTagPreference(sourceMetadata.tags, preferredTags))
+		) {
 			continue;
 		}
 
@@ -1262,6 +1284,7 @@ const selectRandomReviewFiles = (
 				modifiedTimeMs: file.modifiedTimeMs,
 				isGrouped: file.isGrouped,
 				groupName: file.groupName,
+				sourceMetadata,
 			},
 			matchedCount,
 			limit,
@@ -1277,6 +1300,7 @@ const selectRandomReviewFiles = (
 export const scanRandomReviewFiles = async (
 	options: RandomReviewOptions,
 	onProgress?: ScanProgressCallback,
+	resolveMetadata?: GalleryMetadataResolver,
 ): Promise<RandomReviewResult> => {
 	const sourcePath = options.sourcePath.trim();
 
@@ -1307,7 +1331,12 @@ export const scanRandomReviewFiles = async (
 		throw new Error("재검토 인덱스를 생성하지 못했습니다.");
 	}
 
-	const selection = selectRandomReviewFiles(indexResult.files, options, limit);
+	const selection = selectRandomReviewFiles(
+		indexResult.files,
+		options,
+		limit,
+		resolveMetadata,
+	);
 
 	return {
 		files: selection.files,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -242,6 +242,18 @@ export const registerIpcHandlers = (crawlerService: CrawlerService): void => {
 		return crawlerService.resetDatabase();
 	});
 
+	ipcMain.handle("tag-preferences-list", () => {
+		return crawlerService.listTagPreferences();
+	});
+
+	ipcMain.handle("tag-preferences-upsert", (_, input) => {
+		return crawlerService.upsertTagPreference(input);
+	});
+
+	ipcMain.handle("tag-preferences-delete", (_, input) => {
+		return crawlerService.deleteTagPreference(input);
+	});
+
 	ipcMain.handle("archive-metadata-recovery-start", () => {
 		return crawlerService.startArchiveMetadataRecovery();
 	});
@@ -304,9 +316,13 @@ export const registerIpcHandlers = (crawlerService: CrawlerService): void => {
 	ipcMain.handle(
 		"random-review-files",
 		async (event, options: RandomReviewOptions) => {
-			const result = await scanRandomReviewFiles(options, (progress) => {
-				event.sender.send("random-review-files-progress", progress);
-			});
+			const result = await scanRandomReviewFiles(
+				options,
+				(progress) => {
+					event.sender.send("random-review-files-progress", progress);
+				},
+				(galleryIds) => crawlerService.getMetadataByGalleryIds(galleryIds),
+			);
 			return {
 				...result,
 				files: attachSourceMetadata(result.files, crawlerService),

--- a/src/main/tag-preferences.ts
+++ b/src/main/tag-preferences.ts
@@ -1,0 +1,98 @@
+import type { DatabaseSync } from "node:sqlite";
+import {
+	getTagPreferenceKey,
+	type TagPreference,
+	type TagPreferenceIdentity,
+	type TagPreferenceInput,
+	type TagPreferenceKind,
+} from "../shared/tag-preferences.ts";
+
+interface TagPreferenceRow {
+	tag_key: string;
+	namespace: string;
+	value: string;
+	kind: TagPreferenceKind;
+	created_at: string;
+	updated_at: string;
+}
+
+const mapTagPreferenceRow = (row: TagPreferenceRow): TagPreference => ({
+	key: row.tag_key,
+	namespace: row.namespace,
+	value: row.value,
+	kind: row.kind,
+	createdAt: row.created_at,
+	updatedAt: row.updated_at,
+});
+
+export const listTagPreferences = (database: DatabaseSync): TagPreference[] => {
+	const rows = database
+		.prepare(
+			`SELECT tag_key, namespace, value, kind, created_at, updated_at
+			 FROM user_tag_preferences
+			 ORDER BY CASE kind WHEN 'preferred' THEN 0 ELSE 1 END,
+			          namespace COLLATE NOCASE ASC,
+			          value COLLATE NOCASE ASC`,
+		)
+		.all() as unknown as TagPreferenceRow[];
+
+	return rows.map(mapTagPreferenceRow);
+};
+
+export const upsertTagPreference = (
+	database: DatabaseSync,
+	input: TagPreferenceInput,
+	now = new Date().toISOString(),
+): TagPreference => {
+	const namespace = input.namespace.trim();
+	const value = input.value.trim();
+	if (
+		!namespace ||
+		!value ||
+		(input.kind !== "preferred" && input.kind !== "excluded")
+	) {
+		throw new Error("저장할 태그 설정이 올바르지 않습니다.");
+	}
+	const key = getTagPreferenceKey({ namespace, value });
+	if (!key) {
+		throw new Error("저장할 태그 설정이 올바르지 않습니다.");
+	}
+
+	database
+		.prepare(
+			`INSERT INTO user_tag_preferences (
+				tag_key, namespace, value, kind, created_at, updated_at
+			 ) VALUES (?, ?, ?, ?, ?, ?)
+			 ON CONFLICT(tag_key) DO UPDATE SET
+				namespace = excluded.namespace,
+				value = excluded.value,
+				kind = excluded.kind,
+				updated_at = excluded.updated_at`,
+		)
+		.run(key, namespace, value, input.kind, now, now);
+
+	const row = database
+		.prepare(
+			`SELECT tag_key, namespace, value, kind, created_at, updated_at
+			 FROM user_tag_preferences WHERE tag_key = ?`,
+		)
+		.get(key) as TagPreferenceRow | undefined;
+	if (!row) {
+		throw new Error("태그 설정을 저장하지 못했습니다.");
+	}
+
+	return mapTagPreferenceRow(row);
+};
+
+export const deleteTagPreference = (
+	database: DatabaseSync,
+	input: TagPreferenceIdentity,
+): void => {
+	const key = getTagPreferenceKey(input);
+	if (!key) {
+		throw new Error("삭제할 태그 설정이 올바르지 않습니다.");
+	}
+	database
+		.prepare("DELETE FROM user_tag_preferences WHERE tag_key = ?")
+		.run(key);
+};

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -46,6 +46,12 @@ const api: {
 			await electronAPI.ipcRenderer.invoke("crawl-db-delete-item", code),
 		resetDatabase: async () =>
 			await electronAPI.ipcRenderer.invoke("crawl-db-reset"),
+		listTagPreferences: async () =>
+			await electronAPI.ipcRenderer.invoke("tag-preferences-list"),
+		upsertTagPreference: async (input) =>
+			await electronAPI.ipcRenderer.invoke("tag-preferences-upsert", input),
+		deleteTagPreference: async (input) =>
+			await electronAPI.ipcRenderer.invoke("tag-preferences-delete", input),
 		startArchiveMetadataRecovery: async () =>
 			await electronAPI.ipcRenderer.invoke("archive-metadata-recovery-start"),
 		enqueueArchiveMetadataRecoveryFiles: async (filePaths) =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -19,6 +19,13 @@ import type {
 } from "../../shared/file-organizer";
 import type { OrganizationReviewIssue } from "../../shared/organization-metadata";
 import {
+	countMatchingTagPreferences,
+	getTagPreferenceKey,
+	type TagPreference,
+	type TagPreferenceIdentity,
+	type TagPreferenceInput,
+} from "../../shared/tag-preferences";
+import {
 	EmptyState,
 	FileTable,
 	GearIcon,
@@ -315,10 +322,23 @@ const matchesFileFilter = (
 const getVisibleFileIndexes = (
 	files: ReviewFileInfo[],
 	filter: FileReviewFilter,
+	preferredTags: TagPreferenceIdentity[],
 ): number[] =>
 	files
 		.map((file, index) => ({ file, index }))
 		.filter(({ file }) => matchesFileFilter(file, filter))
+		.map(({ file, index }) => ({
+			file,
+			index,
+			preferredTagMatchCount: file.sourceMetadata
+				? countMatchingTagPreferences(file.sourceMetadata.tags, preferredTags)
+				: 0,
+		}))
+		.sort(
+			(left, right) =>
+				right.preferredTagMatchCount - left.preferredTagMatchCount ||
+				left.index - right.index,
+		)
 		.map(({ index }) => index);
 
 function App(): React.JSX.Element {
@@ -341,11 +361,17 @@ function App(): React.JSX.Element {
 	const [scanComplete, setScanComplete] = useState(false);
 	const [selectedRowIndex, setSelectedRowIndex] = useState<number>(-1);
 	const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+	const [tagPreferences, setTagPreferences] = useState<TagPreference[]>([]);
 	const reviewRunIdRef = useRef(0);
 	const tableContainerRef = useRef<HTMLDivElement>(null);
+	const preferredTags = useMemo(
+		() =>
+			tagPreferences.filter((preference) => preference.kind === "preferred"),
+		[tagPreferences],
+	);
 	const visibleFileIndexes = useMemo(
-		() => getVisibleFileIndexes(fileList, activeFileFilter),
-		[fileList, activeFileFilter],
+		() => getVisibleFileIndexes(fileList, activeFileFilter, preferredTags),
+		[fileList, activeFileFilter, preferredTags],
 	);
 	const thumbnailProgress = useFileThumbnails({
 		enabled: thumbnailEnabled,
@@ -394,6 +420,26 @@ function App(): React.JSX.Element {
 
 		return unsubscribe;
 	}, []);
+
+	useEffect(() => {
+		if (activeTab !== "files") return;
+		let isCancelled = false;
+
+		window.api.crawlerDb
+			.listTagPreferences()
+			.then((preferences) => {
+				if (!isCancelled) {
+					setTagPreferences(preferences);
+				}
+			})
+			.catch((error) => {
+				console.error("사용자 태그 설정 조회 실패:", error);
+			});
+
+		return () => {
+			isCancelled = true;
+		};
+	}, [activeTab]);
 
 	// 파일 목록/필터가 변경될 때 선택된 인덱스 초기화
 	useEffect(() => {
@@ -575,6 +621,42 @@ function App(): React.JSX.Element {
 						: file,
 				),
 			);
+		},
+		[],
+	);
+
+	const handleUpsertTagPreference = useCallback(
+		async (input: TagPreferenceInput): Promise<void> => {
+			try {
+				const saved = await window.api.crawlerDb.upsertTagPreference(input);
+				setTagPreferences((current) => [
+					...current.filter((preference) => preference.key !== saved.key),
+					saved,
+				]);
+			} catch (error) {
+				console.error("사용자 태그 설정 저장 실패:", error);
+				alert(
+					`태그 설정을 저장하지 못했습니다.\n${error instanceof Error ? error.message : "알 수 없는 오류"}`,
+				);
+			}
+		},
+		[],
+	);
+
+	const handleDeleteTagPreference = useCallback(
+		async (input: TagPreferenceIdentity): Promise<void> => {
+			try {
+				await window.api.crawlerDb.deleteTagPreference(input);
+				const deletedKey = getTagPreferenceKey(input);
+				setTagPreferences((current) =>
+					current.filter((preference) => preference.key !== deletedKey),
+				);
+			} catch (error) {
+				console.error("사용자 태그 설정 삭제 실패:", error);
+				alert(
+					`태그 설정을 삭제하지 못했습니다.\n${error instanceof Error ? error.message : "알 수 없는 오류"}`,
+				);
+			}
 		},
 		[],
 	);
@@ -783,6 +865,9 @@ function App(): React.JSX.Element {
 										onMoveToFavoriteArtist={handleMoveToFavoriteArtist}
 										onRequestSourceMetadata={requestSourceMetadata}
 										isRequestingSourceMetadata={isRequestingSourceMetadata}
+										tagPreferences={tagPreferences}
+										onUpsertTagPreference={handleUpsertTagPreference}
+										onDeleteTagPreference={handleDeleteTagPreference}
 									/>
 								</div>
 							)}

--- a/src/renderer/src/components/CrawlerDbPanel.tsx
+++ b/src/renderer/src/components/CrawlerDbPanel.tsx
@@ -12,6 +12,7 @@ import {
 	type HitomiCatalogIndexStatus,
 } from "../../../shared/crawler";
 import { DatabaseIcon, ListIcon } from "./Icons";
+import { TagPreferencesPanel } from "./TagPreferencesPanel";
 
 interface FormState {
 	code: string;
@@ -78,6 +79,7 @@ const EMPTY_STATUS: CrawlerStatusSnapshot = {
 	downloadSent: 0,
 	downloadInvalid: 0,
 	downloadFailed: 0,
+	downloadExcluded: 0,
 	downloadLastError: null,
 	currentCursor: null,
 	startedAt: null,
@@ -462,8 +464,9 @@ export const CrawlerDbPanel = (): React.JSX.Element => {
 						{isReadOnly && (
 							<div className="alert alert-warning py-3">
 								<span>
-									크롤링 또는 메타데이터 작업 실행 중에는 DB 수정과 초기화가
-									잠깁니다. 조회만 가능합니다.
+									크롤링 또는 메타데이터 작업 실행 중에는 크롤링 항목 수정과
+									전체 초기화가 잠깁니다. 사용자 태그 설정은 계속 변경할 수
+									있습니다.
 								</span>
 							</div>
 						)}
@@ -494,6 +497,8 @@ export const CrawlerDbPanel = (): React.JSX.Element => {
 								</div>
 							</div>
 						</div>
+
+						<TagPreferencesPanel />
 
 						<div
 							className={`alert py-3 ${

--- a/src/renderer/src/components/CrawlerPanel.tsx
+++ b/src/renderer/src/components/CrawlerPanel.tsx
@@ -34,6 +34,7 @@ const EMPTY_STATUS: CrawlerStatusSnapshot = {
 	downloadSent: 0,
 	downloadInvalid: 0,
 	downloadFailed: 0,
+	downloadExcluded: 0,
 	downloadLastError: null,
 	currentCursor: null,
 	startedAt: null,
@@ -677,7 +678,8 @@ export const CrawlerPanel = (): React.JSX.Element => {
 							</div>
 							<div className="stat-desc text-xs">
 								요청 {status.downloadRequested}건 · 무효{" "}
-								{status.downloadInvalid}건 · 실패 {status.downloadFailed}건
+								{status.downloadInvalid}건 · 실패 {status.downloadFailed}건 ·
+								제외 {status.downloadExcluded}건
 							</div>
 						</div>
 					</div>
@@ -783,20 +785,21 @@ export const CrawlerPanel = (): React.JSX.Element => {
 						</div>
 					</div>
 
-					{status.downloadRequested > 0 && (
+					{status.downloadRequested > 0 || status.downloadExcluded > 0 ? (
 						<div
 							className={`alert mb-3 flex-shrink-0 py-2 text-sm ${status.downloadFailed > 0 ? "alert-warning" : "alert-success"}`}
 						>
 							<span>
 								Hitomi Downloader 자동 전송: 요청 {status.downloadRequested}건 ·
 								성공 {status.downloadSent}건 · 무효 {status.downloadInvalid}건 ·
-								실패 {status.downloadFailed}건
+								실패 {status.downloadFailed}건 · 제외 {status.downloadExcluded}
+								건
 								{status.downloadLastError
 									? ` · 마지막 오류: ${status.downloadLastError}`
 									: ""}
 							</span>
 						</div>
-					)}
+					) : null}
 
 					<div className="flex-1 overflow-hidden rounded-box border border-base-content/5">
 						<div className="overflow-auto h-full">

--- a/src/renderer/src/components/FileTable.tsx
+++ b/src/renderer/src/components/FileTable.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import type { RefObject } from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { GallerySourceTag } from "../../../shared/gallery-metadata";
 import {
@@ -426,6 +426,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 		tag: null,
 	});
 	const tagContextMenuRef = useRef<HTMLDivElement>(null);
+	const tagContextMenuTriggerRef = useRef<HTMLButtonElement | null>(null);
 	const detailDialogRef = useRef<HTMLDialogElement>(null);
 	const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
 	const displayFileIndexes = useMemo(
@@ -445,6 +446,25 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 	);
 	const selectedFile =
 		selectedRowIndex >= 0 ? fileList[selectedRowIndex] : undefined;
+	const closeTagContextMenu = useCallback((restoreFocus = false): void => {
+		setTagContextMenu({ isOpen: false, x: 0, y: 0, tag: null });
+		const trigger = tagContextMenuTriggerRef.current;
+		if (!restoreFocus) {
+			tagContextMenuTriggerRef.current = null;
+			return;
+		}
+
+		window.requestAnimationFrame(() => {
+			if (
+				tagContextMenuTriggerRef.current !== trigger ||
+				!trigger?.isConnected
+			) {
+				return;
+			}
+			trigger.focus();
+			tagContextMenuTriggerRef.current = null;
+		});
+	}, []);
 
 	useEffect(() => {
 		const handleClickOutside = () => {
@@ -452,7 +472,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 				setContextMenu({ isOpen: false, x: 0, y: 0, file: null });
 			}
 			if (tagContextMenu.isOpen) {
-				setTagContextMenu({ isOpen: false, x: 0, y: 0, tag: null });
+				closeTagContextMenu();
 			}
 		};
 
@@ -461,7 +481,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 				setContextMenu({ isOpen: false, x: 0, y: 0, file: null });
 			}
 			if (e.key === "Escape" && tagContextMenu.isOpen) {
-				setTagContextMenu({ isOpen: false, x: 0, y: 0, tag: null });
+				closeTagContextMenu(true);
 			}
 		};
 
@@ -472,7 +492,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 			document.removeEventListener("click", handleClickOutside);
 			document.removeEventListener("keydown", handleEscape);
 		};
-	}, [contextMenu.isOpen, tagContextMenu.isOpen]);
+	}, [closeTagContextMenu, contextMenu.isOpen, tagContextMenu.isOpen]);
 
 	useEffect(() => {
 		if (!selectedFile) {
@@ -493,7 +513,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 		}
 
 		const handleEscape = (event: KeyboardEvent): void => {
-			if (event.key === "Escape") {
+			if (event.key === "Escape" && !tagContextMenu.isOpen) {
 				setIsDetailModalOpen(false);
 			}
 		};
@@ -503,7 +523,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 		return () => {
 			document.removeEventListener("keydown", handleEscape);
 		};
-	}, [isDetailModalOpen]);
+	}, [isDetailModalOpen, tagContextMenu.isOpen]);
 
 	const handleContextMenu = (e: React.MouseEvent, file: TFile) => {
 		e.preventDefault();
@@ -515,15 +535,17 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 			y: e.clientY,
 			file,
 		});
-		setTagContextMenu({ isOpen: false, x: 0, y: 0, tag: null });
+		closeTagContextMenu();
 	};
 
 	const openTagContextMenu = (
 		tag: GallerySourceTag,
 		x: number,
 		y: number,
+		trigger: HTMLButtonElement,
 	): void => {
 		setContextMenu({ isOpen: false, x: 0, y: 0, file: null });
+		tagContextMenuTriggerRef.current = trigger;
 		setTagContextMenu({
 			isOpen: true,
 			x: Math.max(8, Math.min(x, window.innerWidth - 226)),
@@ -533,12 +555,12 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 	};
 
 	const handleTagContextMenu = (
-		event: React.MouseEvent,
+		event: React.MouseEvent<HTMLButtonElement>,
 		tag: GallerySourceTag,
 	): void => {
 		event.preventDefault();
 		event.stopPropagation();
-		openTagContextMenu(tag, event.clientX, event.clientY);
+		openTagContextMenu(tag, event.clientX, event.clientY, event.currentTarget);
 	};
 
 	const handleTagKeyDown = (
@@ -553,7 +575,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 		event.preventDefault();
 		event.stopPropagation();
 		const rect = event.currentTarget.getBoundingClientRect();
-		openTagContextMenu(tag, rect.left, rect.bottom);
+		openTagContextMenu(tag, rect.left, rect.bottom, event.currentTarget);
 	};
 
 	const handleTagClick = (
@@ -562,7 +584,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 	): void => {
 		event.stopPropagation();
 		const rect = event.currentTarget.getBoundingClientRect();
-		openTagContextMenu(tag, rect.left, rect.bottom);
+		openTagContextMenu(tag, rect.left, rect.bottom, event.currentTarget);
 	};
 
 	const getTagPreference = (
@@ -586,7 +608,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 				kind: action,
 			});
 		}
-		setTagContextMenu({ isOpen: false, x: 0, y: 0, tag: null });
+		closeTagContextMenu(true);
 	};
 
 	const handleMenuItemClick = (
@@ -1748,12 +1770,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 					if (event.key === "Escape") {
 						event.preventDefault();
 						event.stopPropagation();
-						setTagContextMenu({
-							isOpen: false,
-							x: 0,
-							y: 0,
-							tag: null,
-						});
+						closeTagContextMenu(true);
 					}
 				}}
 			>

--- a/src/renderer/src/components/FileTable.tsx
+++ b/src/renderer/src/components/FileTable.tsx
@@ -1,6 +1,16 @@
 import type React from "react";
 import type { RefObject } from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { GallerySourceTag } from "../../../shared/gallery-metadata";
+import {
+	countMatchingTagPreferences,
+	getTagPreferenceKey,
+	type TagPreference,
+	type TagPreferenceIdentity,
+	type TagPreferenceInput,
+	type TagPreferenceKind,
+} from "../../../shared/tag-preferences";
 import type {
 	DuplicateAction,
 	FileInfo,
@@ -65,6 +75,11 @@ interface FileTableProps<TFile extends TableFileInfo = ReviewFileInfo> {
 	onMoveToFavoriteArtist?: (file: TFile) => void;
 	onRequestSourceMetadata?: (file: TFile) => void | Promise<void>;
 	isRequestingSourceMetadata?: (file: TFile) => boolean;
+	tagPreferences?: TagPreference[];
+	onUpsertTagPreference?: (input: TagPreferenceInput) => void | Promise<void>;
+	onDeleteTagPreference?: (
+		input: TagPreferenceIdentity,
+	) => void | Promise<void>;
 }
 
 interface ContextMenuState<TFile extends TableFileInfo = ReviewFileInfo> {
@@ -72,6 +87,13 @@ interface ContextMenuState<TFile extends TableFileInfo = ReviewFileInfo> {
 	x: number;
 	y: number;
 	file: TFile | null;
+}
+
+interface TagContextMenuState {
+	isOpen: boolean;
+	x: number;
+	y: number;
+	tag: GallerySourceTag | null;
 }
 
 interface StatusInfo {
@@ -387,6 +409,9 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 	onMoveToFavoriteArtist,
 	onRequestSourceMetadata,
 	isRequestingSourceMetadata,
+	tagPreferences = [],
+	onUpsertTagPreference,
+	onDeleteTagPreference,
 }: FileTableProps<TFile>): React.JSX.Element => {
 	const [contextMenu, setContextMenu] = useState<ContextMenuState<TFile>>({
 		isOpen: false,
@@ -394,12 +419,30 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 		y: 0,
 		file: null,
 	});
+	const [tagContextMenu, setTagContextMenu] = useState<TagContextMenuState>({
+		isOpen: false,
+		x: 0,
+		y: 0,
+		tag: null,
+	});
+	const tagContextMenuRef = useRef<HTMLDivElement>(null);
+	const detailDialogRef = useRef<HTMLDialogElement>(null);
 	const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
 	const displayFileIndexes = useMemo(
 		() => visibleFileIndexes ?? fileList.map((_, index) => index),
 		[fileList, visibleFileIndexes],
 	);
 	const filterCounts = useMemo(() => getFilterCounts(fileList), [fileList]);
+	const preferredTagPreferences = useMemo(
+		() =>
+			tagPreferences.filter((preference) => preference.kind === "preferred"),
+		[tagPreferences],
+	);
+	const tagPreferencesByKey = useMemo(
+		() =>
+			new Map(tagPreferences.map((preference) => [preference.key, preference])),
+		[tagPreferences],
+	);
 	const selectedFile =
 		selectedRowIndex >= 0 ? fileList[selectedRowIndex] : undefined;
 
@@ -408,11 +451,17 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 			if (contextMenu.isOpen) {
 				setContextMenu({ isOpen: false, x: 0, y: 0, file: null });
 			}
+			if (tagContextMenu.isOpen) {
+				setTagContextMenu({ isOpen: false, x: 0, y: 0, tag: null });
+			}
 		};
 
 		const handleEscape = (e: KeyboardEvent) => {
 			if (e.key === "Escape" && contextMenu.isOpen) {
 				setContextMenu({ isOpen: false, x: 0, y: 0, file: null });
+			}
+			if (e.key === "Escape" && tagContextMenu.isOpen) {
+				setTagContextMenu({ isOpen: false, x: 0, y: 0, tag: null });
 			}
 		};
 
@@ -423,13 +472,20 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 			document.removeEventListener("click", handleClickOutside);
 			document.removeEventListener("keydown", handleEscape);
 		};
-	}, [contextMenu.isOpen]);
+	}, [contextMenu.isOpen, tagContextMenu.isOpen]);
 
 	useEffect(() => {
 		if (!selectedFile) {
 			setIsDetailModalOpen(false);
 		}
 	}, [selectedFile]);
+
+	useEffect(() => {
+		if (!tagContextMenu.isOpen) return;
+		tagContextMenuRef.current
+			?.querySelector<HTMLButtonElement>("button:not(:disabled)")
+			?.focus();
+	}, [tagContextMenu.isOpen]);
 
 	useEffect(() => {
 		if (!isDetailModalOpen) {
@@ -459,6 +515,78 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 			y: e.clientY,
 			file,
 		});
+		setTagContextMenu({ isOpen: false, x: 0, y: 0, tag: null });
+	};
+
+	const openTagContextMenu = (
+		tag: GallerySourceTag,
+		x: number,
+		y: number,
+	): void => {
+		setContextMenu({ isOpen: false, x: 0, y: 0, file: null });
+		setTagContextMenu({
+			isOpen: true,
+			x: Math.max(8, Math.min(x, window.innerWidth - 226)),
+			y: Math.max(8, Math.min(y, window.innerHeight - 176)),
+			tag,
+		});
+	};
+
+	const handleTagContextMenu = (
+		event: React.MouseEvent,
+		tag: GallerySourceTag,
+	): void => {
+		event.preventDefault();
+		event.stopPropagation();
+		openTagContextMenu(tag, event.clientX, event.clientY);
+	};
+
+	const handleTagKeyDown = (
+		event: React.KeyboardEvent<HTMLButtonElement>,
+		tag: GallerySourceTag,
+	): void => {
+		if (
+			!((event.shiftKey && event.key === "F10") || event.key === "ContextMenu")
+		) {
+			return;
+		}
+		event.preventDefault();
+		event.stopPropagation();
+		const rect = event.currentTarget.getBoundingClientRect();
+		openTagContextMenu(tag, rect.left, rect.bottom);
+	};
+
+	const handleTagClick = (
+		event: React.MouseEvent<HTMLButtonElement>,
+		tag: GallerySourceTag,
+	): void => {
+		event.stopPropagation();
+		const rect = event.currentTarget.getBoundingClientRect();
+		openTagContextMenu(tag, rect.left, rect.bottom);
+	};
+
+	const getTagPreference = (
+		tag: TagPreferenceIdentity,
+	): TagPreference | undefined => {
+		const key = getTagPreferenceKey(tag);
+		return key ? tagPreferencesByKey.get(key) : undefined;
+	};
+
+	const handleTagPreferenceAction = async (
+		action: TagPreferenceKind | "remove",
+	): Promise<void> => {
+		const tag = tagContextMenu.tag;
+		if (!tag) return;
+		if (action === "remove") {
+			await onDeleteTagPreference?.(tag);
+		} else {
+			await onUpsertTagPreference?.({
+				namespace: tag.namespace,
+				value: tag.value,
+				kind: action,
+			});
+		}
+		setTagContextMenu({ isOpen: false, x: 0, y: 0, tag: null });
 	};
 
 	const handleMenuItemClick = (
@@ -606,6 +734,65 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 		);
 	};
 
+	const getPreferredTagMatchCount = (file: TableFileInfo): number =>
+		file.sourceMetadata
+			? countMatchingTagPreferences(
+					file.sourceMetadata.tags,
+					preferredTagPreferences,
+				)
+			: 0;
+
+	const renderPreferredTagBadge = (
+		file: TableFileInfo,
+		size: "xs" | "sm" = "xs",
+	): React.JSX.Element | null => {
+		const matchCount = getPreferredTagMatchCount(file);
+		if (matchCount === 0) return null;
+
+		return (
+			<span
+				className={`badge badge-secondary ${size === "sm" ? "badge-sm" : "badge-xs"}`}
+				title={`선호 태그 ${matchCount}개가 일치합니다.`}
+			>
+				선호 태그 {matchCount}
+			</span>
+		);
+	};
+
+	const renderSourceTag = (
+		namespace: string,
+		value: string,
+	): React.JSX.Element => {
+		const tag: GallerySourceTag = { namespace, value, position: 0 };
+		const preference = getTagPreference(tag);
+		const className =
+			preference?.kind === "preferred"
+				? "badge-secondary"
+				: preference?.kind === "excluded"
+					? "badge-error"
+					: "badge-outline";
+
+		return (
+			<button
+				type="button"
+				key={`${namespace}:${value}`}
+				className={`badge badge-sm ${className} cursor-context-menu focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-primary`}
+				title={
+					preference
+						? `${preference.kind === "preferred" ? "선호" : "제외"} 태그 · 우클릭 또는 Shift+F10으로 변경`
+						: "우클릭 또는 Shift+F10으로 태그 설정"
+				}
+				aria-haspopup="menu"
+				aria-label={`${getSourceTagNamespaceLabel(namespace)} ${value} 태그 설정 열기`}
+				onClick={(event) => handleTagClick(event, tag)}
+				onContextMenu={(event) => handleTagContextMenu(event, tag)}
+				onKeyDown={(event) => handleTagKeyDown(event, tag)}
+			>
+				{value}
+			</button>
+		);
+	};
+
 	const renderCardThumbnail = (file: TFile): React.JSX.Element => {
 		if (!file.thumbnail) {
 			if (file.thumbnailLoadState === "loading") {
@@ -694,6 +881,8 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 										);
 										const statusInfo = getReviewStatusInfo(file);
 										const isSelected = selectedRowIndex === fileIndex;
+										const preferredTagMatchCount =
+											getPreferredTagMatchCount(file);
 										const groupedLabel = file.groupName
 											? `그룹화됨: ${file.groupName}`
 											: "그룹화됨";
@@ -708,10 +897,12 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 												className={`hover cursor-pointer focus:outline focus:outline-2 focus:outline-offset-[-2px] focus:outline-primary ${
 													isSelected
 														? "bg-primary/20 hover:bg-primary/30"
-														: file.isGrouped
-															? "bg-warning/5"
-															: ""
-												}`}
+														: preferredTagMatchCount > 0
+															? "bg-secondary/10 hover:bg-secondary/15"
+															: file.isGrouped
+																? "bg-warning/5"
+																: ""
+												} ${preferredTagMatchCount > 0 ? "border-l-4 border-secondary" : ""}`}
 												onFocus={() => onRowClick(fileIndex)}
 												onClick={() => onRowClick(fileIndex)}
 												onKeyDown={(event) =>
@@ -763,6 +954,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 																</span>
 															)}
 															{renderFavoriteArtistBadge(file)}
+															{renderPreferredTagBadge(file)}
 														</div>
 														<div
 															className="truncate text-sm font-medium"
@@ -860,6 +1052,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 									file.sourceMetadata,
 								);
 								const isSelected = selectedRowIndex === fileIndex;
+								const preferredTagMatchCount = getPreferredTagMatchCount(file);
 								const title = displayData.title || "제목 정보 없음";
 								const groupedLabel = file.groupName
 									? `그룹화됨: ${file.groupName}`
@@ -874,8 +1067,10 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 										className={`flex w-full cursor-pointer flex-col gap-4 rounded-box border bg-base-100 p-3 text-left shadow-sm transition-colors focus:outline focus:outline-2 focus:outline-primary sm:flex-row ${
 											isSelected
 												? "border-primary/60 bg-primary/5"
-												: "border-base-content/10 hover:border-primary/30 hover:bg-base-100/80"
-										}`}
+												: preferredTagMatchCount > 0
+													? "border-secondary/50 bg-secondary/5 hover:border-secondary"
+													: "border-base-content/10 hover:border-primary/30 hover:bg-base-100/80"
+										} ${preferredTagMatchCount > 0 ? "ring-1 ring-secondary/20" : ""}`}
 										onFocus={() => onRowClick(fileIndex)}
 										onClick={() => onRowClick(fileIndex)}
 										onKeyDown={(event) =>
@@ -914,6 +1109,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 															</span>
 														)}
 														{renderFavoriteArtistBadge(file, "sm")}
+														{renderPreferredTagBadge(file, "sm")}
 													</div>
 													<div className="break-words text-lg font-semibold leading-snug text-base-content">
 														{title}
@@ -1085,6 +1281,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 									</span>
 								)}
 								{renderFavoriteArtistBadge(selectedFile, "sm")}
+								{renderPreferredTagBadge(selectedFile, "sm")}
 							</div>
 						)}
 						<h2
@@ -1107,14 +1304,9 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 											{getSourceTagNamespaceLabel(group.namespace)}
 										</div>
 										<div className="flex flex-wrap gap-1.5">
-											{group.values.map((value) => (
-												<span
-													key={`${group.namespace}:${value}`}
-													className="badge badge-outline badge-sm"
-												>
-													{value}
-												</span>
-											))}
+											{group.values.map((value) =>
+												renderSourceTag(group.namespace, value),
+											)}
 										</div>
 									</div>
 								))}
@@ -1538,6 +1730,80 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 		);
 	};
 
+	const renderTagContextMenu = (): React.JSX.Element | null => {
+		const tag = tagContextMenu.tag;
+		if (!tagContextMenu.isOpen || !tag) return null;
+		const preference = getTagPreference(tag);
+
+		const menu = (
+			<div
+				ref={tagContextMenuRef}
+				className="fixed z-[60] min-w-[210px] rounded-box border border-base-content/10 bg-base-100 py-2 shadow-[0_8px_24px_rgba(0,0,0,0.5)]"
+				style={{ left: tagContextMenu.x, top: tagContextMenu.y }}
+				role="menu"
+				tabIndex={-1}
+				aria-label={`${tag.value} 태그 설정`}
+				onClick={(event) => event.stopPropagation()}
+				onKeyDown={(event) => {
+					if (event.key === "Escape") {
+						event.preventDefault();
+						event.stopPropagation();
+						setTagContextMenu({
+							isOpen: false,
+							x: 0,
+							y: 0,
+							tag: null,
+						});
+					}
+				}}
+			>
+				<div className="mb-2 border-b border-base-content/10 px-3 py-2">
+					<div className="truncate text-sm font-semibold">{tag.value}</div>
+					<div className="truncate font-mono text-[11px] text-base-content/50">
+						{tag.namespace}
+					</div>
+				</div>
+				<button
+					type="button"
+					className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors hover:bg-secondary/10 focus:bg-secondary/10 focus:outline-none disabled:opacity-60"
+					role="menuitem"
+					disabled={!onUpsertTagPreference || preference?.kind === "preferred"}
+					onClick={() => void handleTagPreferenceAction("preferred")}
+				>
+					<span>선호 태그로 설정</span>
+					{preference?.kind === "preferred" && (
+						<span className="badge badge-secondary badge-xs">현재</span>
+					)}
+				</button>
+				<button
+					type="button"
+					className="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm transition-colors hover:bg-error/10 focus:bg-error/10 focus:outline-none disabled:opacity-60"
+					role="menuitem"
+					disabled={!onUpsertTagPreference || preference?.kind === "excluded"}
+					onClick={() => void handleTagPreferenceAction("excluded")}
+				>
+					<span>제외 태그로 설정</span>
+					{preference?.kind === "excluded" && (
+						<span className="badge badge-error badge-xs">현재</span>
+					)}
+				</button>
+				{preference && (
+					<button
+						type="button"
+						className="mt-1 flex w-full items-center gap-2 border-t border-base-content/10 px-3 py-2 text-left text-sm text-error transition-colors hover:bg-error/10 focus:bg-error/10 focus:outline-none"
+						role="menuitem"
+						disabled={!onDeleteTagPreference}
+						onClick={() => void handleTagPreferenceAction("remove")}
+					>
+						설정 해제
+					</button>
+				)}
+			</div>
+		);
+
+		return createPortal(menu, detailDialogRef.current ?? document.body);
+	};
+
 	return (
 		<>
 			<div className="grid min-h-0 flex-1 gap-3 overflow-hidden [@media(min-width:1440px)]:grid-cols-[minmax(0,1fr)_minmax(300px,360px)]">
@@ -1552,6 +1818,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 			</div>
 			{onFilterChange && isDetailModalOpen && (
 				<dialog
+					ref={detailDialogRef}
 					className="modal modal-open [@media(min-width:1440px)]:hidden"
 					open
 				>
@@ -1589,6 +1856,7 @@ export const FileTable = <TFile extends TableFileInfo = ReviewFileInfo>({
 				</dialog>
 			)}
 			{renderContextMenu()}
+			{renderTagContextMenu()}
 		</>
 	);
 };

--- a/src/renderer/src/components/RandomReviewPanel.tsx
+++ b/src/renderer/src/components/RandomReviewPanel.tsx
@@ -1,10 +1,11 @@
 import type React from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
 	RandomReviewOptions,
 	RandomReviewResult,
 	ScanArchiveProgress,
 } from "../../../shared/file-organizer";
+import type { TagPreference } from "../../../shared/tag-preferences";
 import { useArchiveMetadataRecovery } from "../hooks/useArchiveMetadataRecovery";
 import { useFileActions } from "../hooks/useFileActions";
 import { useFileThumbnails } from "../hooks/useFileThumbnails";
@@ -12,6 +13,7 @@ import { useKeyboardNavigation } from "../hooks/useKeyboardNavigation";
 import { useScrollToRow } from "../hooks/useScrollToRow";
 import type { FileInfo } from "../types";
 import { getRelativePath, parseFileStructure } from "../utils/file";
+import { getSourceTagNamespaceLabel } from "../utils/gallery-metadata";
 import { FileTable } from "./FileTable";
 import { LoadingState } from "./LoadingState";
 
@@ -128,6 +130,12 @@ export const RandomReviewPanel = (): React.JSX.Element => {
 	const [maxSizeMb, setMaxSizeMb] = useState("");
 	const [recursive, setRecursive] = useState(true);
 	const [thumbnailEnabled, setThumbnailEnabled] = useState(true);
+	const [preferredTagPreferences, setPreferredTagPreferences] = useState<
+		TagPreference[]
+	>([]);
+	const [selectedPreferredTagKeys, setSelectedPreferredTagKeys] = useState<
+		string[]
+	>([]);
 	const [fileList, setFileList] = useState<FileInfo[]>([]);
 	const [selectedRowIndex, setSelectedRowIndex] = useState(-1);
 	const [scanComplete, setScanComplete] = useState(false);
@@ -193,6 +201,32 @@ export const RandomReviewPanel = (): React.JSX.Element => {
 	}, []);
 
 	useEffect(() => {
+		let isCancelled = false;
+
+		window.api.crawlerDb
+			.listTagPreferences()
+			.then((preferences) => {
+				if (isCancelled) return;
+				const preferred = preferences.filter(
+					(preference) => preference.kind === "preferred",
+				);
+				setPreferredTagPreferences(preferred);
+				setSelectedPreferredTagKeys((current) =>
+					current.filter((key) =>
+						preferred.some((preference) => preference.key === key),
+					),
+				);
+			})
+			.catch((error) => {
+				console.error("선호 태그 설정 조회 실패:", error);
+			});
+
+		return () => {
+			isCancelled = true;
+		};
+	}, []);
+
+	useEffect(() => {
 		const unsubscribe = window.api.fileOrganizer.onRandomReviewProgress(
 			(progress) => {
 				setScanProgress(progress);
@@ -217,6 +251,25 @@ export const RandomReviewPanel = (): React.JSX.Element => {
 		setScanProgress(null);
 		setReviewSummary(null);
 	}, []);
+	const selectedPreferredTags = useMemo(
+		() =>
+			preferredTagPreferences.filter((preference) =>
+				selectedPreferredTagKeys.includes(preference.key),
+			),
+		[preferredTagPreferences, selectedPreferredTagKeys],
+	);
+
+	const togglePreferredTag = useCallback(
+		(key: string): void => {
+			setSelectedPreferredTagKeys((current) =>
+				current.includes(key)
+					? current.filter((currentKey) => currentKey !== key)
+					: [...current, key],
+			);
+			resetResultState();
+		},
+		[resetResultState],
+	);
 
 	const handleSelectPath = useCallback(async (): Promise<void> => {
 		try {
@@ -274,6 +327,13 @@ export const RandomReviewPanel = (): React.JSX.Element => {
 				maxSizeBytes,
 				recursive,
 				forceRefresh,
+				preferredTags:
+					selectedPreferredTags.length > 0
+						? selectedPreferredTags.map((preference) => ({
+								namespace: preference.namespace,
+								value: preference.value,
+							}))
+						: undefined,
 			};
 		},
 		[
@@ -285,6 +345,7 @@ export const RandomReviewPanel = (): React.JSX.Element => {
 			minSizeMb,
 			recursive,
 			reviewLimit,
+			selectedPreferredTags,
 			sourcePath,
 		],
 	);
@@ -558,6 +619,65 @@ export const RandomReviewPanel = (): React.JSX.Element => {
 							/>
 						</label>
 					</div>
+
+					<fieldset className="rounded-box border border-secondary/20 bg-secondary/5 p-3">
+						<legend className="sr-only">선호 태그 필터</legend>
+						<div className="flex flex-wrap items-center justify-between gap-2">
+							<div className="text-xs font-semibold">선호 태그 필터</div>
+							<div className="flex items-center gap-2">
+								<span className="badge badge-secondary badge-sm">
+									선택 {selectedPreferredTags.length}개
+								</span>
+								{selectedPreferredTagKeys.length > 0 && (
+									<button
+										type="button"
+										className="btn btn-ghost btn-xs"
+										disabled={isScanning}
+										onClick={() => {
+											setSelectedPreferredTagKeys([]);
+											resetResultState();
+										}}
+									>
+										전체 해제
+									</button>
+								)}
+							</div>
+						</div>
+						{preferredTagPreferences.length === 0 ? (
+							<div className="mt-2 text-xs text-base-content/55">
+								DB 관리에서 선호 태그를 먼저 등록해주세요.
+							</div>
+						) : (
+							<div className="mt-2 flex max-h-24 flex-wrap gap-1.5 overflow-y-auto">
+								{preferredTagPreferences.map((preference) => {
+									const isSelected = selectedPreferredTagKeys.includes(
+										preference.key,
+									);
+									return (
+										<button
+											type="button"
+											key={preference.key}
+											className={`btn btn-xs ${isSelected ? "btn-secondary" : "btn-ghost"}`}
+											disabled={isScanning}
+											aria-pressed={isSelected}
+											onClick={() => togglePreferredTag(preference.key)}
+										>
+											<span className="font-mono opacity-60">
+												{getSourceTagNamespaceLabel(preference.namespace)}
+											</span>
+											{preference.value}
+										</button>
+									);
+								})}
+							</div>
+						)}
+						{selectedPreferredTags.length > 0 && (
+							<div className="mt-2 text-[11px] text-base-content/55">
+								선택한 태그 중 하나라도 포함된 작품만 추출합니다. gallery ID
+								또는 원천 메타데이터가 없는 파일은 결과에서 제외됩니다.
+							</div>
+						)}
+					</fieldset>
 				</div>
 			</div>
 
@@ -646,6 +766,11 @@ export const RandomReviewPanel = (): React.JSX.Element => {
 									갱신 {formatIndexedAt(reviewSummary.indexedAt)}
 								</div>
 							</>
+						)}
+						{selectedPreferredTags.length > 0 && (
+							<div className="badge badge-secondary badge-sm">
+								선호 태그 OR {selectedPreferredTags.length}개
+							</div>
 						)}
 					</div>
 					<FileTable

--- a/src/renderer/src/components/TagPreferencesPanel.tsx
+++ b/src/renderer/src/components/TagPreferencesPanel.tsx
@@ -1,0 +1,289 @@
+import type React from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type {
+	TagPreference,
+	TagPreferenceKind,
+} from "../../../shared/tag-preferences";
+import { getSourceTagNamespaceLabel } from "../utils/gallery-metadata";
+
+const TAG_NAMESPACE_OPTIONS = [
+	"artist",
+	"group",
+	"parody",
+	"language",
+	"character",
+	"female",
+	"male",
+	"mixed",
+	"cosplayer",
+	"reclass",
+	"other",
+	"unknown",
+];
+
+const getKindLabel = (kind: TagPreferenceKind): string =>
+	kind === "preferred" ? "선호" : "제외";
+
+export const TagPreferencesPanel = (): React.JSX.Element => {
+	const [preferences, setPreferences] = useState<TagPreference[]>([]);
+	const [kind, setKind] = useState<TagPreferenceKind>("preferred");
+	const [namespace, setNamespace] = useState("female");
+	const [value, setValue] = useState("");
+	const [isLoading, setIsLoading] = useState(true);
+	const [isMutating, setIsMutating] = useState(false);
+
+	const loadPreferences = useCallback(async (): Promise<void> => {
+		try {
+			setIsLoading(true);
+			setPreferences(await window.api.crawlerDb.listTagPreferences());
+		} catch (error) {
+			console.error("사용자 태그 설정 조회 실패:", error);
+			alert(
+				`사용자 태그 설정을 불러오지 못했습니다.\n${error instanceof Error ? error.message : "알 수 없는 오류"}`,
+			);
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		void loadPreferences();
+	}, [loadPreferences]);
+
+	const preferencesByKind = useMemo(
+		() => ({
+			preferred: preferences.filter(
+				(preference) => preference.kind === "preferred",
+			),
+			excluded: preferences.filter(
+				(preference) => preference.kind === "excluded",
+			),
+		}),
+		[preferences],
+	);
+
+	const upsertPreference = useCallback(
+		async (
+			nextKind: TagPreferenceKind,
+			nextNamespace: string,
+			nextValue: string,
+		): Promise<void> => {
+			try {
+				setIsMutating(true);
+				const saved = await window.api.crawlerDb.upsertTagPreference({
+					kind: nextKind,
+					namespace: nextNamespace,
+					value: nextValue,
+				});
+				setPreferences((current) =>
+					[...current.filter((item) => item.key !== saved.key), saved].sort(
+						(left, right) =>
+							left.kind.localeCompare(right.kind) ||
+							left.namespace.localeCompare(right.namespace) ||
+							left.value.localeCompare(right.value),
+					),
+				);
+			} catch (error) {
+				console.error("사용자 태그 설정 저장 실패:", error);
+				alert(
+					`사용자 태그 설정을 저장하지 못했습니다.\n${error instanceof Error ? error.message : "알 수 없는 오류"}`,
+				);
+			} finally {
+				setIsMutating(false);
+			}
+		},
+		[],
+	);
+
+	const handleSubmit = useCallback(
+		async (event: React.FormEvent): Promise<void> => {
+			event.preventDefault();
+			const trimmedNamespace = namespace.trim();
+			const trimmedValue = value.trim();
+			if (!trimmedNamespace || !trimmedValue) {
+				alert("namespace와 태그명을 모두 입력해주세요.");
+				return;
+			}
+			await upsertPreference(kind, trimmedNamespace, trimmedValue);
+			setValue("");
+		},
+		[kind, namespace, upsertPreference, value],
+	);
+
+	const handleDelete = useCallback(
+		async (preference: TagPreference): Promise<void> => {
+			const confirmed = confirm(
+				`${getSourceTagNamespaceLabel(preference.namespace)}: ${preference.value} 설정을 삭제하시겠습니까?`,
+			);
+			if (!confirmed) return;
+
+			try {
+				setIsMutating(true);
+				await window.api.crawlerDb.deleteTagPreference(preference);
+				setPreferences((current) =>
+					current.filter((item) => item.key !== preference.key),
+				);
+			} catch (error) {
+				console.error("사용자 태그 설정 삭제 실패:", error);
+				alert(
+					`사용자 태그 설정을 삭제하지 못했습니다.\n${error instanceof Error ? error.message : "알 수 없는 오류"}`,
+				);
+			} finally {
+				setIsMutating(false);
+			}
+		},
+		[],
+	);
+
+	const renderPreferenceList = (
+		listKind: TagPreferenceKind,
+	): React.JSX.Element => {
+		const list = preferencesByKind[listKind];
+		const nextKind = listKind === "preferred" ? "excluded" : "preferred";
+
+		return (
+			<section
+				className={`rounded-box border p-3 ${
+					listKind === "preferred"
+						? "border-secondary/25 bg-secondary/5"
+						: "border-error/25 bg-error/5"
+				}`}
+			>
+				<div className="mb-2 flex items-center justify-between gap-2">
+					<div className="font-semibold">{getKindLabel(listKind)} 태그</div>
+					<span
+						className={`badge badge-sm ${listKind === "preferred" ? "badge-secondary" : "badge-error"}`}
+					>
+						{list.length}개
+					</span>
+				</div>
+				<div className="max-h-48 space-y-1 overflow-y-auto pr-1">
+					{list.length === 0 ? (
+						<div className="rounded bg-base-100/70 px-3 py-4 text-center text-xs text-base-content/55">
+							등록된 태그가 없습니다.
+						</div>
+					) : (
+						list.map((preference) => (
+							<div
+								key={preference.key}
+								className="flex items-center gap-2 rounded bg-base-100/80 px-2 py-2"
+							>
+								<div className="min-w-0 flex-1">
+									<div className="truncate text-sm font-medium">
+										{preference.value}
+									</div>
+									<div className="truncate font-mono text-[11px] text-base-content/50">
+										{preference.namespace}
+									</div>
+								</div>
+								<button
+									type="button"
+									className="btn btn-ghost btn-xs"
+									disabled={isMutating}
+									aria-label={`${preference.value} 태그를 ${getKindLabel(nextKind)} 태그로 전환`}
+									onClick={() =>
+										void upsertPreference(
+											nextKind,
+											preference.namespace,
+											preference.value,
+										)
+									}
+								>
+									{getKindLabel(nextKind)}로
+								</button>
+								<button
+									type="button"
+									className="btn btn-error btn-outline btn-xs"
+									disabled={isMutating}
+									aria-label={`${preference.value} 태그 설정 삭제`}
+									onClick={() => void handleDelete(preference)}
+								>
+									삭제
+								</button>
+							</div>
+						))
+					)}
+				</div>
+			</section>
+		);
+	};
+
+	return (
+		<section className="rounded-box border border-primary/20 bg-primary/5 p-4">
+			<div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+				<div>
+					<div className="flex flex-wrap items-center gap-2">
+						<h3 className="font-semibold">사용자 태그 관리</h3>
+						<span className="badge badge-secondary badge-sm">
+							선호 {preferencesByKind.preferred.length}
+						</span>
+						<span className="badge badge-error badge-sm">
+							제외 {preferencesByKind.excluded.length}
+						</span>
+					</div>
+					<p className="mt-1 text-xs text-base-content/60">
+						선호 태그는 검토 우선순위와 랜덤 재검토 필터에 사용하고, 제외 태그는
+						신규 다운로드 전송을 차단합니다.
+					</p>
+				</div>
+				{isLoading && (
+					<span
+						className="loading loading-spinner loading-sm"
+						role="status"
+						aria-label="태그 설정 불러오는 중"
+					/>
+				)}
+			</div>
+
+			<form
+				className="mt-3 grid gap-2 md:grid-cols-[140px_180px_minmax(0,1fr)_auto]"
+				onSubmit={(event) => void handleSubmit(event)}
+			>
+				<select
+					className="select select-bordered select-sm"
+					value={kind}
+					disabled={isMutating}
+					aria-label="태그 분류"
+					onChange={(event) => setKind(event.target.value as TagPreferenceKind)}
+				>
+					<option value="preferred">선호 태그</option>
+					<option value="excluded">제외 태그</option>
+				</select>
+				<input
+					className="input input-bordered input-sm font-mono"
+					list="tag-namespace-options"
+					value={namespace}
+					disabled={isMutating}
+					placeholder="namespace"
+					aria-label="태그 namespace"
+					onChange={(event) => setNamespace(event.target.value)}
+				/>
+				<datalist id="tag-namespace-options">
+					{TAG_NAMESPACE_OPTIONS.map((option) => (
+						<option key={option} value={option} />
+					))}
+				</datalist>
+				<input
+					className="input input-bordered input-sm"
+					value={value}
+					disabled={isMutating}
+					placeholder="태그명"
+					aria-label="태그명"
+					onChange={(event) => setValue(event.target.value)}
+				/>
+				<button
+					type="submit"
+					className="btn btn-primary btn-sm"
+					disabled={isMutating || !namespace.trim() || !value.trim()}
+				>
+					추가
+				</button>
+			</form>
+
+			<div className="mt-3 grid gap-3 md:grid-cols-2">
+				{renderPreferenceList("preferred")}
+				{renderPreferenceList("excluded")}
+			</div>
+		</section>
+	);
+};

--- a/src/shared/crawler.ts
+++ b/src/shared/crawler.ts
@@ -1,4 +1,9 @@
 import type { GallerySourceMetadata } from "./gallery-metadata";
+import type {
+	TagPreference,
+	TagPreferenceIdentity,
+	TagPreferenceInput,
+} from "./tag-preferences";
 
 export const CRAWLER_TARGET_URL =
 	"https://e-hentai.org/?f_search=korean&f_srdd=3";
@@ -104,6 +109,7 @@ export interface CrawlerStatusSnapshot {
 	downloadSent: number;
 	downloadInvalid: number;
 	downloadFailed: number;
+	downloadExcluded: number;
 	downloadLastError: string | null;
 	currentCursor: string | null;
 	startedAt: string | null;
@@ -231,6 +237,9 @@ export interface CrawlerDatabaseApi {
 	) => Promise<CrawlItem>;
 	deleteItem: (code: string) => Promise<void>;
 	resetDatabase: () => Promise<CrawlDatabaseResetResult>;
+	listTagPreferences: () => Promise<TagPreference[]>;
+	upsertTagPreference: (input: TagPreferenceInput) => Promise<TagPreference>;
+	deleteTagPreference: (input: TagPreferenceIdentity) => Promise<void>;
 	startArchiveMetadataRecovery: () => Promise<ArchiveMetadataRecoverySnapshot>;
 	enqueueArchiveMetadataRecoveryFiles: (
 		filePaths: string[],

--- a/src/shared/file-organizer.ts
+++ b/src/shared/file-organizer.ts
@@ -4,6 +4,7 @@ import type {
 	OrganizationMetadataSource,
 	OrganizationReviewIssue,
 } from "./organization-metadata";
+import type { TagPreferenceIdentity } from "./tag-preferences";
 
 export interface FileThumbnail {
 	dataUrl: string;
@@ -52,6 +53,7 @@ export interface RandomReviewOptions {
 	maxSizeBytes?: number;
 	recursive: boolean;
 	forceRefresh?: boolean;
+	preferredTags?: TagPreferenceIdentity[];
 }
 
 export interface RandomReviewResult {

--- a/src/shared/tag-preferences.ts
+++ b/src/shared/tag-preferences.ts
@@ -1,0 +1,69 @@
+import type { GallerySourceTag } from "./gallery-metadata.ts";
+
+export type TagPreferenceKind = "preferred" | "excluded";
+
+export interface TagPreferenceIdentity {
+	namespace: string;
+	value: string;
+}
+
+export interface TagPreferenceInput extends TagPreferenceIdentity {
+	kind: TagPreferenceKind;
+}
+
+export interface TagPreference extends TagPreferenceInput {
+	key: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+const normalizeTagPreferencePart = (value: string): string =>
+	value.trim().toLocaleLowerCase("en-US");
+
+export const getTagPreferenceKey = (
+	tag: TagPreferenceIdentity,
+): string | null => {
+	const namespace = normalizeTagPreferencePart(tag.namespace);
+	const value = normalizeTagPreferencePart(tag.value);
+	if (!namespace || !value) {
+		return null;
+	}
+
+	return JSON.stringify([namespace, value]);
+};
+
+export const getMatchingTagPreferences = (
+	tags: GallerySourceTag[],
+	preferences: TagPreferenceIdentity[],
+): TagPreferenceIdentity[] => {
+	const preferencesByKey = new Map(
+		preferences
+			.map(
+				(preference) => [getTagPreferenceKey(preference), preference] as const,
+			)
+			.filter(
+				(entry): entry is [string, TagPreferenceIdentity] => entry[0] !== null,
+			),
+	);
+	const matches = new Map<string, TagPreferenceIdentity>();
+
+	for (const tag of tags) {
+		const key = getTagPreferenceKey(tag);
+		const preference = key ? preferencesByKey.get(key) : undefined;
+		if (key && preference) {
+			matches.set(key, preference);
+		}
+	}
+
+	return [...matches.values()];
+};
+
+export const matchesAnyTagPreference = (
+	tags: GallerySourceTag[],
+	preferences: TagPreferenceIdentity[],
+): boolean => getMatchingTagPreferences(tags, preferences).length > 0;
+
+export const countMatchingTagPreferences = (
+	tags: GallerySourceTag[],
+	preferences: TagPreferenceIdentity[],
+): number => getMatchingTagPreferences(tags, preferences).length;

--- a/tests/crawler-database.test.mjs
+++ b/tests/crawler-database.test.mjs
@@ -5,9 +5,16 @@ import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import test from "node:test";
 import {
+	clearCrawlerDatabaseContent,
 	getMetadataBackfillFailedGalleryIds,
 	initializeCrawlerDatabase,
 } from "../src/main/crawler-database.ts";
+import {
+	listTagPreferences,
+	upsertTagPreference,
+} from "../src/main/tag-preferences.ts";
+
+const TARGET_URL = "https://e-hentai.org/?f_search=korean&f_srdd=3";
 
 const LEGACY_RUN_SCHEMA = `
 	CREATE TABLE crawl_runs (
@@ -69,6 +76,7 @@ test("기존 crawler DB를 마이그레이션하고 메타데이터 FK cascade�
 		assert.ok(runColumns.includes("download_sent"));
 		assert.ok(runColumns.includes("download_invalid"));
 		assert.ok(runColumns.includes("download_failed"));
+		assert.ok(runColumns.includes("download_excluded"));
 		assert.ok(runColumns.includes("download_last_error"));
 		const crawlMetadataColumns = database
 			.prepare("PRAGMA table_info(crawl_item_metadata)")
@@ -87,6 +95,7 @@ test("기존 crawler DB를 마이그레이션하고 메타데이터 FK cascade�
 			"last_error",
 			"updated_at",
 			"sent_at",
+			"excluded_tag_key",
 		]);
 		const backfillJobColumns = database
 			.prepare("PRAGMA table_info(crawl_metadata_backfill_jobs)")
@@ -333,6 +342,47 @@ test("기존 crawler DB를 마이그레이션하고 메타데이터 FK cascade�
 			database.prepare("SELECT COUNT(*) AS count FROM crawl_item_tags").get()
 				.count,
 			0,
+		);
+	} finally {
+		database.close();
+		rmSync(tempDirectory, { recursive: true, force: true });
+	}
+});
+
+test("크롤링 DB 콘텐츠 초기화는 사용자 태그 설정을 보존한다", () => {
+	const tempDirectory = mkdtempSync(
+		path.join(tmpdir(), "rosemary-crawler-db-"),
+	);
+	const database = new DatabaseSync(path.join(tempDirectory, "crawler.sqlite"));
+
+	try {
+		initializeCrawlerDatabase(database);
+		upsertTagPreference(
+			database,
+			{ namespace: "female", value: "tag a", kind: "excluded" },
+			"2026-07-30T00:00:00.000Z",
+		);
+		database
+			.prepare(
+				`INSERT INTO crawl_state (
+					target_url, default_max_pages, updated_at
+				) VALUES (?, 10, ?)`,
+			)
+			.run(TARGET_URL, "2026-07-30T00:00:00.000Z");
+
+		clearCrawlerDatabaseContent(database);
+
+		assert.equal(
+			database.prepare("SELECT COUNT(*) AS count FROM crawl_state").get().count,
+			0,
+		);
+		assert.deepEqual(
+			listTagPreferences(database).map(({ namespace, value, kind }) => ({
+				namespace,
+				value,
+				kind,
+			})),
+			[{ namespace: "female", value: "tag a", kind: "excluded" }],
 		);
 	} finally {
 		database.close();

--- a/tests/crawler-download-dispatch.test.mjs
+++ b/tests/crawler-download-dispatch.test.mjs
@@ -8,6 +8,7 @@ import { initializeCrawlerDatabase } from "../src/main/crawler-database.ts";
 import {
 	applyDownloadDispatchResult,
 	getDownloadDispatchSummary,
+	markDownloadDispatchRowsExcluded,
 	selectDownloadDispatchRows,
 } from "../src/main/crawler-download-dispatch.ts";
 
@@ -114,6 +115,7 @@ test("부분 전송 후 실패 항목만 재시도하고 성공·무효 항목�
 			sent: 2,
 			invalid: 1,
 			failed: 0,
+			excluded: 0,
 			lastError: null,
 		});
 		assert.deepEqual(
@@ -130,6 +132,85 @@ test("부분 전송 후 실패 항목만 재시도하고 성공·무효 항목�
 				{ gallery_id: "2000", status: "invalid", attempt_count: 1 },
 				{ gallery_id: "3000", status: "sent", attempt_count: 2 },
 			],
+		);
+	} finally {
+		database.close();
+		rmSync(tempDirectory, { recursive: true, force: true });
+	}
+});
+
+test("제외 태그와 일치한 항목은 전송 대상에서 빠지고 별도 상태로 집계한다", () => {
+	const tempDirectory = mkdtempSync(path.join(tmpdir(), "rosemary-dispatch-"));
+	const database = new DatabaseSync(path.join(tempDirectory, "crawler.sqlite"));
+	try {
+		initializeCrawlerDatabase(database);
+		const runId = Number(
+			database
+				.prepare(
+					`INSERT INTO crawl_runs (
+						target_url, status, phase, max_pages, started_at
+					) VALUES (?, 'completed', 'idle', 1, ?)`,
+				)
+				.run(TARGET_URL, NOW).lastInsertRowid,
+		);
+		const insertItem = database.prepare(
+			`INSERT INTO crawl_items (
+				code, target_url, type, name, link, created_run_id, discovered_at
+			) VALUES (?, ?, 'Manga', ?, ?, ?, ?)`,
+		);
+		const insertDispatch = database.prepare(
+			`INSERT INTO crawl_download_dispatch_items (
+				run_id, gallery_id, status, updated_at
+			) VALUES (?, ?, 'pending', ?)`,
+		);
+		for (const galleryId of ["1000", "2000"]) {
+			insertItem.run(
+				galleryId,
+				TARGET_URL,
+				`Fixture ${galleryId}`,
+				`https://e-hentai.org/g/${galleryId}/0000000001/`,
+				runId,
+				NOW,
+			);
+			insertDispatch.run(runId, galleryId, NOW);
+		}
+
+		markDownloadDispatchRowsExcluded(
+			database,
+			runId,
+			[{ galleryId: "1000", tagKey: '["female","tag a"]' }],
+			NOW,
+		);
+
+		assert.deepEqual(
+			selectDownloadDispatchRows(database, runId, ["pending"]).map(
+				(row) => row.galleryId,
+			),
+			["2000"],
+		);
+		assert.deepEqual(getDownloadDispatchSummary(database, runId), {
+			requested: 1,
+			sent: 0,
+			invalid: 0,
+			failed: 0,
+			excluded: 1,
+			lastError: null,
+		});
+		assert.deepEqual(
+			{
+				...database
+					.prepare(
+						`SELECT status, attempt_count, excluded_tag_key
+						 FROM crawl_download_dispatch_items
+						 WHERE run_id = ? AND gallery_id = '1000'`,
+					)
+					.get(runId),
+			},
+			{
+				status: "excluded",
+				attempt_count: 0,
+				excluded_tag_key: '["female","tag a"]',
+			},
 		);
 	} finally {
 		database.close();

--- a/tests/tag-preferences.test.mjs
+++ b/tests/tag-preferences.test.mjs
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import test from "node:test";
+import { initializeCrawlerDatabase } from "../src/main/crawler-database.ts";
+import {
+	deleteTagPreference,
+	listTagPreferences,
+	upsertTagPreference,
+} from "../src/main/tag-preferences.ts";
+import {
+	countMatchingTagPreferences,
+	getMatchingTagPreferences,
+	getTagPreferenceKey,
+	matchesAnyTagPreference,
+} from "../src/shared/tag-preferences.ts";
+
+const NOW = "2026-07-30T00:00:00.000Z";
+const LATER = "2026-07-30T00:01:00.000Z";
+
+test("태그는 namespace와 값을 정규화한 조합으로 구분한다", () => {
+	assert.equal(
+		getTagPreferenceKey({ namespace: " Artist ", value: "Some Tag " }),
+		getTagPreferenceKey({ namespace: "artist", value: "some tag" }),
+	);
+	assert.notEqual(
+		getTagPreferenceKey({ namespace: "artist", value: "same" }),
+		getTagPreferenceKey({ namespace: "female", value: "same" }),
+	);
+	assert.equal(getTagPreferenceKey({ namespace: "", value: "tag" }), null);
+});
+
+test("작품 태그는 선택한 선호 태그 중 하나라도 일치하면 포함하고 일치 개수를 센다", () => {
+	const tags = [
+		{ namespace: "artist", value: "Source Artist", position: 0 },
+		{ namespace: "female", value: "Tag A", position: 1 },
+		{ namespace: "female", value: "Tag B", position: 2 },
+	];
+	const preferences = [
+		{ namespace: "ARTIST", value: "source artist" },
+		{ namespace: "female", value: "tag b" },
+		{ namespace: "male", value: "tag a" },
+	];
+
+	assert.equal(matchesAnyTagPreference(tags, preferences), true);
+	assert.equal(countMatchingTagPreferences(tags, preferences), 2);
+	assert.deepEqual(
+		getMatchingTagPreferences(tags, preferences).map((item) => item.value),
+		["source artist", "tag b"],
+	);
+});
+
+test("동일 태그를 다시 저장하면 선호와 제외가 상호 전환되고 DB 재연결 후에도 유지된다", () => {
+	const tempDirectory = mkdtempSync(
+		path.join(tmpdir(), "rosemary-tag-preferences-"),
+	);
+	const databasePath = path.join(tempDirectory, "crawler.sqlite");
+	let database = new DatabaseSync(databasePath);
+
+	try {
+		initializeCrawlerDatabase(database);
+		const preferred = upsertTagPreference(
+			database,
+			{
+				namespace: " female ",
+				value: "Tag A",
+				kind: "preferred",
+			},
+			NOW,
+		);
+		const excluded = upsertTagPreference(
+			database,
+			{
+				namespace: "FEMALE",
+				value: "tag a",
+				kind: "excluded",
+			},
+			LATER,
+		);
+
+		assert.equal(preferred.key, excluded.key);
+		assert.equal(excluded.kind, "excluded");
+		assert.equal(excluded.createdAt, NOW);
+		assert.equal(excluded.updatedAt, LATER);
+		assert.equal(listTagPreferences(database).length, 1);
+
+		database.close();
+		database = new DatabaseSync(databasePath);
+		initializeCrawlerDatabase(database);
+		assert.deepEqual(
+			listTagPreferences(database).map(({ kind, namespace, value }) => ({
+				kind,
+				namespace,
+				value,
+			})),
+			[{ kind: "excluded", namespace: "FEMALE", value: "tag a" }],
+		);
+
+		deleteTagPreference(database, {
+			namespace: "female",
+			value: "TAG A",
+		});
+		assert.deepEqual(listTagPreferences(database), []);
+	} finally {
+		database.close();
+		rmSync(tempDirectory, { recursive: true, force: true });
+	}
+});


### PR DESCRIPTION
## Summary

- Add persistent preferred and excluded tag preferences.
- Apply tag preferences across crawler scanning, download dispatch, file organization, and review flows.
- Add renderer controls and IPC/preload support for managing tag preferences.
- Add regression coverage for database, download dispatch, and tag-preference behavior.

## Testing

- Added automated coverage for crawler database, download dispatch, and tag-preference flows.
- Not run (not requested).