### PR TITLE
Fix Hitomi API port binding on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rosemary-app",
-	"version": "8.4.0",
+	"version": "8.4.1",
 	"description": "An Electron application with React and TypeScript",
 	"main": "./out/main/index.js",
 	"author": "example.com",
@@ -17,6 +17,7 @@
 		"typecheck": "pnpm run typecheck:node && pnpm run typecheck:web",
 		"test:metadata": "node --experimental-strip-types --test tests/gallery-metadata.test.mjs tests/organization-metadata.test.mjs tests/archive-metadata-recovery.test.mjs tests/crawler-database.test.mjs tests/crawler-download-dispatch.test.mjs tests/crawler-metadata-integration.test.mjs tests/crawler-request-policy.test.mjs tests/hitomi-catalog-index.test.mjs tests/tag-preferences.test.mjs",
 		"test:startup": "node --experimental-strip-types --test tests/runtime-paths.test.mjs",
+		"test:hitomi-api": "node --experimental-strip-types --test tests/hitomi-api-script.test.mjs",
 		"smoke:start": "pnpm run build && node scripts/smoke-electron-start.mjs",
 		"start": "electron-vite preview",
 		"dev": "electron-vite dev",

--- a/src/main/hitomi-api-script.ts
+++ b/src/main/hitomi-api-script.ts
@@ -1,0 +1,25 @@
+export const HITOMI_API_HOST = "127.0.0.1";
+export const HITOMI_API_PORT = 16009;
+export const HITOMI_API_BASE_URL = `http://${HITOMI_API_HOST}:${HITOMI_API_PORT}`;
+
+const UPSTREAM_BINDING = `http.server.ThreadingHTTPServer(("${HITOMI_API_HOST}", 6009), RequestHandler)`;
+const CONFIGURED_BINDING = `http.server.ThreadingHTTPServer(("${HITOMI_API_HOST}", ${HITOMI_API_PORT}), RequestHandler)`;
+
+export const configureHitomiApiScript = (scriptBuffer: Buffer): Buffer => {
+	const scriptText = scriptBuffer.toString("utf8");
+	if (scriptText.includes(CONFIGURED_BINDING)) {
+		return scriptBuffer;
+	}
+
+	const bindingCount = scriptText.split(UPSTREAM_BINDING).length - 1;
+	if (bindingCount !== 1) {
+		throw new Error(
+			"Hitomi API 확장 파일의 서버 설정 형식이 예상과 달라 안전하게 설치할 수 없습니다.",
+		);
+	}
+
+	return Buffer.from(
+		scriptText.replace(UPSTREAM_BINDING, CONFIGURED_BINDING),
+		"utf8",
+	);
+};

--- a/src/main/hitomi-api.ts
+++ b/src/main/hitomi-api.ts
@@ -9,6 +9,10 @@ import type {
 	HitomiApiStatusResult,
 } from "../shared/settings";
 import {
+	configureHitomiApiScript,
+	HITOMI_API_BASE_URL,
+} from "./hitomi-api-script";
+import {
 	ensurePathExists,
 	isProcessRunningByExecutablePath,
 	launchDetachedProcess,
@@ -16,7 +20,6 @@ import {
 	waitForProcessByExecutablePath,
 } from "./process-utils";
 
-const HITOMI_API_BASE_URL = "http://127.0.0.1:6009";
 const HITOMI_API_SCRIPT_DOWNLOAD_URL =
 	"https://github.com/Hitomi-Downloader-extension/api/releases/download/0.1.0/api.hds";
 const HITOMI_API_REQUEST_TIMEOUT_MS = 5000;
@@ -330,7 +333,9 @@ export const installHitomiApiExtension = async (
 	);
 
 	const { scriptsDirectory, scriptPath } = buildApiScriptPath(executablePath);
-	const scriptBuffer = await downloadHitomiApiScript();
+	const scriptBuffer = configureHitomiApiScript(
+		await downloadHitomiApiScript(),
+	);
 	await fs.promises.mkdir(scriptsDirectory, { recursive: true });
 
 	let backupPath: string | null = null;

--- a/src/renderer/src/components/Settings.tsx
+++ b/src/renderer/src/components/Settings.tsx
@@ -227,7 +227,7 @@ export const Settings = ({
 								<div className="flex flex-col gap-1">
 									<div className="font-semibold">Hitomi API 연동</div>
 									<div className="text-xs text-base-content/60">
-										API는 로컬 주소 127.0.0.1:6009만 사용합니다.
+										API는 로컬 주소 127.0.0.1:16009만 사용합니다.
 									</div>
 								</div>
 								<div className="flex flex-wrap gap-2">

--- a/tests/hitomi-api-script.test.mjs
+++ b/tests/hitomi-api-script.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+	configureHitomiApiScript,
+	HITOMI_API_BASE_URL,
+} from "../src/main/hitomi-api-script.ts";
+
+test("Windows 예약 포트를 피해 Hitomi API 서버 포트를 변경한다", () => {
+	const upstreamScript = Buffer.from(
+		'prefix\n    server = http.server.ThreadingHTTPServer(("127.0.0.1", 6009), RequestHandler)\nsuffix\n',
+		"utf8",
+	);
+
+	const configuredScript =
+		configureHitomiApiScript(upstreamScript).toString("utf8");
+
+	assert.equal(HITOMI_API_BASE_URL, "http://127.0.0.1:16009");
+	assert.match(configuredScript, /"127\.0\.0\.1", 16009/);
+	assert.doesNotMatch(configuredScript, /"127\.0\.0\.1", 6009/);
+});
+
+test("이미 변경된 Hitomi API 확장 파일은 그대로 유지한다", () => {
+	const configuredScript = Buffer.from(
+		'http.server.ThreadingHTTPServer(("127.0.0.1", 16009), RequestHandler)',
+		"utf8",
+	);
+
+	assert.equal(configureHitomiApiScript(configuredScript), configuredScript);
+});
+
+test("예상하지 못한 서버 형식은 손상시키지 않고 설치를 중단한다", () => {
+	assert.throws(
+		() => configureHitomiApiScript(Buffer.from("unexpected upstream script")),
+		/서버 설정 형식이 예상과 달라/,
+	);
+});


### PR DESCRIPTION
## 변경 내용
- Windows 예약 포트 범위와 충돌하는 Hitomi API 기본 포트 6009를 로컬 전용 16009로 변경
- 공식 `api.hds` 설치 시 서버 바인딩을 안전하게 변환하고, 예상하지 못한 upstream 형식은 설치 중단
- 설정 화면 안내와 앱 요청 주소를 동일하게 갱신
- 패치 버전 8.4.1 및 변환 회귀 테스트 추가

## 검증
- `pnpm check`
- `pnpm typecheck`
- `pnpm test:hitomi-api` (3 passed)
- `pnpm test:metadata` (42 passed)
- `pnpm test:startup` (3 passed)
- `pnpm build:win`
- 패키지 `app.asar`에서 `http://127.0.0.1:16009` 확인
- 실제 Hitomi Downloader 런타임 `/ping` 응답 `{"status":"ok"}` 확인