### PR TITLE
Fix packaged app window lifecycle before 8.4.2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"test:startup": "node --experimental-strip-types --test tests/runtime-paths.test.mjs",
 		"test:hitomi-api": "node --experimental-strip-types --test tests/hitomi-api-script.test.mjs",
 		"smoke:start": "pnpm run build && node scripts/smoke-electron-start.mjs",
+		"smoke:packaged-start": "node scripts/smoke-packaged-start.mjs",
 		"start": "electron-vite preview",
 		"dev": "electron-vite dev",
 		"build": "pnpm run typecheck && electron-vite build",

--- a/scripts/smoke-packaged-start.mjs
+++ b/scripts/smoke-packaged-start.mjs
@@ -1,0 +1,70 @@
+import { spawn } from "node:child_process";
+import { access, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const projectRoot = path.resolve(import.meta.dirname, "..");
+const executablePath = path.join(
+	projectRoot,
+	"dist",
+	"win-unpacked",
+	"rosemary-app.exe",
+);
+await access(executablePath);
+
+const profilePath = await mkdtemp(
+	path.join(tmpdir(), "rosemary-packaged-smoke-"),
+);
+const output = [];
+const child = spawn(executablePath, [], {
+	cwd: path.dirname(executablePath),
+	env: {
+		...process.env,
+		ELECTRON_ENABLE_LOGGING: "1",
+		ROSEMARY_VALIDATION_USER_DATA_PATH: profilePath,
+	},
+	stdio: ["ignore", "pipe", "pipe"],
+});
+
+child.stdout.on("data", (chunk) => output.push(chunk.toString()));
+child.stderr.on("data", (chunk) => output.push(chunk.toString()));
+
+const exitPromise = new Promise((resolve, reject) => {
+	child.once("error", reject);
+	child.once("exit", (code, signal) => {
+		resolve({ code, signal });
+	});
+});
+
+try {
+	const result = await Promise.race([
+		exitPromise,
+		new Promise((resolve) => {
+			setTimeout(() => resolve(null), 4_000);
+		}),
+	]);
+
+	if (result) {
+		throw new Error(
+			`패키징된 Rosemary가 조기에 종료되었습니다. code=${result.code}, signal=${result.signal}`,
+		);
+	}
+
+	console.log(`패키징된 Rosemary 시작 유지 테스트 통과: ${executablePath}`);
+} catch (error) {
+	console.error(error instanceof Error ? error.message : String(error));
+	console.error("--- Electron 로그 ---");
+	console.error(output.join("").trim());
+	process.exitCode = 1;
+} finally {
+	if (child.exitCode === null) {
+		child.kill();
+		await Promise.race([
+			exitPromise,
+			new Promise((resolve) => {
+				setTimeout(resolve, 2_000);
+			}),
+		]);
+	}
+	await rm(profilePath, { recursive: true, force: true, maxRetries: 3 });
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,10 +1,24 @@
 import * as fs from "node:fs";
 import { electronApp, optimizer } from "@electron-toolkit/utils";
-import { app, BrowserWindow } from "electron";
+import { app, type BrowserWindow } from "electron";
 import { CrawlerService } from "./crawler";
 import { registerIpcHandlers } from "./ipc";
 import { resolveRuntimeProfilePaths } from "./runtime-paths";
 import { createMainWindow } from "./window";
+
+let mainWindow: BrowserWindow | null = null;
+
+const openMainWindow = (options?: { showOnReady?: boolean }): BrowserWindow => {
+	const createdWindow = createMainWindow(options);
+	mainWindow = createdWindow;
+	createdWindow.once("closed", () => {
+		if (mainWindow === createdWindow) {
+			mainWindow = null;
+		}
+	});
+
+	return createdWindow;
+};
 
 const runtimeProfile = resolveRuntimeProfilePaths({
 	appDataPath: app.getPath("appData"),
@@ -42,9 +56,9 @@ void app
 
 		registerIpcHandlers(crawlerService);
 		const isSmokeTest = process.env.ROSEMARY_SMOKE_TEST === "1";
-		const mainWindow = createMainWindow({ showOnReady: !isSmokeTest });
+		const createdMainWindow = openMainWindow({ showOnReady: !isSmokeTest });
 		if (isSmokeTest) {
-			mainWindow.webContents.once("did-finish-load", () => {
+			createdMainWindow.webContents.once("did-finish-load", () => {
 				console.info("[Rosemary 시작] 준비 완료");
 				setTimeout(() => app.quit(), 500);
 			});
@@ -53,8 +67,8 @@ void app
 		}
 
 		app.on("activate", () => {
-			if (BrowserWindow.getAllWindows().length === 0) {
-				createMainWindow();
+			if (!mainWindow || mainWindow.isDestroyed()) {
+				openMainWindow();
 			}
 		});
 	})


### PR DESCRIPTION
## 릴리스 차단 오류
병합된 8.4.2 설치판을 실제 실행했을 때 프로세스가 즉시 정상 종료됐습니다. `BrowserWindow`가 `whenReady()` 콜백의 지역 변수로만 유지되어 창 수명보다 먼저 참조가 사라지는 것이 원인이었습니다.

## 수정
- main 프로세스가 현재 `BrowserWindow`를 앱 수명 동안 명시적으로 보유
- 창 종료 시 참조를 해제하고 macOS 재활성화 시 다시 생성
- 패키징된 실행 파일이 4초 이상 유지되는 회귀 스모크 추가
- 이미 정한 8.4.2 릴리스 범위 내 후속 수정이므로 버전은 유지

## 검증
- `pnpm check`
- `pnpm typecheck`
- 테스트 48개 통과
- `pnpm smoke:start`
- `pnpm build:win`
- `pnpm smoke:packaged-start`